### PR TITLE
Lock Stripe.Net to 41.x.

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.3" />
-    <PackageReference Include="Stripe.net" Version="41.28.0" />
+    <PackageReference Include="Stripe.net" Version="41.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrading Stripe.Net to another major version requires manual intervention in the Stripe dashboard.