### PR TITLE
Removing existing user requirement

### DIFF
--- a/src/Service/Fido2Service.cs
+++ b/src/Service/Fido2Service.cs
@@ -261,11 +261,6 @@ public class Fido2Service : IFido2Service
     {
         ValidateUserId(request.UserId);
 
-        if (!await _storage.UserExists(request.UserId))
-        {
-            throw new ApiException("invalid_user", $"{request.UserId} is not recognized.", 400);
-        }
-
         _eventLogger.LogSigninTokenCreatedEvent(request.UserId);
 
         var tokenProps = new VerifySignInToken

--- a/src/Service/Storage/Ef/EfTenantStorage.cs
+++ b/src/Service/Storage/Ef/EfTenantStorage.cs
@@ -298,11 +298,6 @@ public class EfTenantStorage : ITenantStorage
         await db.SaveChangesAsync();
     }
 
-    public Task<bool> UserExists(string userId) =>
-        db.Credentials.Where(x => x.UserId == userId).Select(x => x.UserId)
-            .Union(db.Aliases.Where(x => x.UserId == userId).Select(x => x.UserId))
-            .AnyAsync();
-
     public async Task<List<UserSummary>> GetUsers(string lastUserId)
     {
         var credentialsPerUser = await db.Credentials

--- a/src/Service/Storage/Ef/ITenantStorage.cs
+++ b/src/Service/Storage/Ef/ITenantStorage.cs
@@ -28,7 +28,6 @@ public interface ITenantStorage
     Task StoreApiKey(string pkpart, string apikey, string[] scopes);
     Task<bool> TenantExists();
     Task UpdateCredential(byte[] credentialId, uint counter, string country, string device);
-    Task<bool> UserExists(string userId);
     Task<List<UserSummary>> GetUsers(string lastUserId);
 
     // Aliases


### PR DESCRIPTION
This removes the existing user requirement from the `/signin/generate-token` endpoint as it unintentionally limited the use of the endpoint. With this in place, the token could not be issued to a user who had yet to create a passkey in the system. By removing the restriction we can allow that use case.