### PR TITLE
Adding rate limiting to Admins.cshtml.cs

### DIFF
--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -1,6 +1,8 @@
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Passwordless.AdminConsole;
 using Passwordless.AdminConsole.Authorization;
@@ -155,6 +157,15 @@ void RunTheApp()
 
     builder.Services.AddAntiforgery();
 
+    builder.Services.AddRateLimiter(limiter => limiter
+        .AddFixedWindowLimiter(policyName: "fixed", options =>
+        {
+            options.PermitLimit = 10;
+            options.Window = TimeSpan.FromMinutes(1);
+            options.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+            options.QueueLimit = 0;
+        }));
+
     WebApplication app;
     try
     {
@@ -192,6 +203,7 @@ void RunTheApp()
     app.UseStaticFiles();
     app.UseSerilogRequestLogging();
     app.UseRouting();
+    app.UseRateLimiter();
     app.UseAntiforgery();
     app.MapHealthEndpoints();
     app.UseAuthentication();

--- a/src/AdminConsole/Services/IInvitationService.cs
+++ b/src/AdminConsole/Services/IInvitationService.cs
@@ -4,7 +4,7 @@ namespace Passwordless.AdminConsole.Services;
 
 public interface IInvitationService
 {
-    Task SendInviteAsync(string toEmail, int TargetOrgId, string TargetOrgName, string fromEmail, string fromName);
+    Task SendInviteAsync(string toEmail, int targetOrgId, string targetOrgName, string fromEmail, string fromName);
     Task<List<Invite>> GetInvitesAsync(int orgId);
     Task CancelInviteAsync(string hashedCode);
     Task<Invite> GetInviteFromRawCodeAsync(string code);

--- a/src/AdminConsole/Services/InvitationService.cs
+++ b/src/AdminConsole/Services/InvitationService.cs
@@ -24,13 +24,13 @@ public class InvitationService<TDbContext> : IInvitationService where TDbContext
         _actionContextAccessor = actionContextAccessor;
     }
 
-    public async Task SendInviteAsync(string toEmail, int TargetOrgId, string TargetOrgName, string fromEmail, string fromName)
+    public async Task SendInviteAsync(string toEmail, int targetOrgId, string targetOrgName, string fromEmail, string fromName)
     {
         var inv = new Invite()
         {
             ToEmail = toEmail,
-            TargetOrgId = TargetOrgId,
-            TargetOrgName = TargetOrgName,
+            TargetOrgId = targetOrgId,
+            TargetOrgName = targetOrgName,
             FromEmail = fromEmail,
             FromName = fromName
         };


### PR DESCRIPTION
This adds rate limiting to the Admins page to address ability to spam emails using the invite admin form.

The settings used are 
```
            options.PermitLimit = 10;
            options.Window = TimeSpan.FromMinutes(1);
            options.QueueLimit = 0;
```

This means we limit 10 requests to the resource for 1 min. The `QueueLimit` determines the number of requests we'll hold in queue to execute later once the limit has been reached. This was set to 0 to drop all requests once the limit is reached.

I had to apply the rate limit attribute to the entire razor page due to a [limitation of the RateLimitMiddleware](https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit?view=aspnetcore-8.0#applying-attributes-to-razor-pages).

In order to also reduce the ability of a user to abuse this page, I enforced a unique restriction on the email the invite is being sent to.  If the email already exists in the invite list, we won't send the invite. They'll have to cancel the old invite first.