### PR TITLE
Protect the POST '/apps/available' endpoint.

### DIFF
--- a/src/AdminConsole/Controller/ApplicationEndpoints.cs
+++ b/src/AdminConsole/Controller/ApplicationEndpoints.cs
@@ -1,0 +1,21 @@
+using Passwordless.AdminConsole.Services.PasswordlessManagement;
+using Passwordless.Common.Models.Apps;
+using static Microsoft.AspNetCore.Http.Results;
+
+namespace Passwordless.AdminConsole.Controller;
+
+public static class ApplicationEndpoints
+{
+    public static IEndpointRouteBuilder MapApplicationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/Applications");
+
+        // The Blazor SSR sample uses the same solution for signing out, but we do not want to use all the endpoints.
+        group.MapGet("/{appId}/Available", async ([AsParameters] GetAppIdAvailabilityRequest request, IPasswordlessManagementClient client) =>
+        {
+            var result = await client.IsApplicationIdAvailableAsync(request);
+            return Ok(result);
+        }).RequireAuthorization();
+        return endpoints;
+    }
+}

--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml
@@ -1,7 +1,4 @@
 @page
-@using Microsoft.Extensions.Options
-@using Passwordless.AdminConsole.Services.PasswordlessManagement
-@inject IOptions<PasswordlessManagementOptions> Options
 @model CreateApplicationModel
 
 @{
@@ -99,17 +96,20 @@
             });
 
             const checkAvailability = async (appId) => {
-                var res = await fetch("@Options.Value.ApiUrl/apps/available", {
-                    method: "POST",
+                let res = await fetch(`/Applications/${appId}/Available`, {
+                    method: "GET",
                     headers: {
                         "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ appId: appId }),
+                    }
                 });
                 return res.ok;
             }
 
             watch(appId, async () => {
+                if (parsedAppId.value.length < 3) {
+                    availability.value = "not-available";
+                    return;
+                }
                 const available = await checkAvailability(parsedAppId.value);
                 availability.value = available ? "available" : "not-available";
             })

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -209,6 +209,7 @@ void RunTheApp()
     }
 
     app.MapAccountEndpoints();
+    app.MapApplicationEndpoints();
 
     app.Run();
 }

--- a/src/AdminConsole/Services/PasswordlessManagement/IPasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/IPasswordlessManagementClient.cs
@@ -19,4 +19,5 @@ public interface IPasswordlessManagementClient
     Task DeleteApiKeyAsync(string appId, string apiKeyId);
     Task EnabledManuallyGeneratedTokensAsync(string appId, string performedBy);
     Task DisabledManuallyGeneratedTokensAsync(string appId, string performedBy);
+    Task<GetAppIdAvailabilityResponse> IsApplicationIdAvailableAsync(GetAppIdAvailabilityRequest request);
 }

--- a/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
@@ -118,4 +118,10 @@ public class PasswordlessManagementClient : IPasswordlessManagementClient
         });
         response.EnsureSuccessStatusCode();
     }
+
+    public async Task<GetAppIdAvailabilityResponse> IsApplicationIdAvailableAsync(GetAppIdAvailabilityRequest request)
+    {
+        var response = await _client.GetFromJsonAsync<GetAppIdAvailabilityResponse>($"admin/apps/{request.AppId}/available");
+        return response!;
+    }
 }

--- a/src/Api/Endpoints/Apps.cs
+++ b/src/Api/Endpoints/Apps.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Helpers;
-using Passwordless.Api.Models;
 using Passwordless.Common.Models.Apps;
 using Passwordless.Service;
 using Passwordless.Service.EventLog.Loggers;
@@ -16,7 +15,7 @@ public static class AppsEndpoints
 {
     public static void MapAccountEndpoints(this WebApplication app)
     {
-        app.MapPost("/apps/available", async (AppAvailable payload, ISharedManagementService accountService) =>
+        app.MapGet("/admin/apps/{appId}/available", async ([AsParameters] GetAppIdAvailabilityRequest payload, ISharedManagementService accountService) =>
             {
                 if (payload.AppId.Length < 3)
                 {
@@ -25,10 +24,11 @@ public static class AppsEndpoints
 
                 var result = await accountService.IsAvailable(payload.AppId);
 
-                var res = new AvailableResponse(result);
+                var res = new GetAppIdAvailabilityResponse(result);
 
                 return result ? Ok(res) : Conflict(res);
             })
+            .RequireManagementKey()
             .RequireCors("default");
 
         app.MapPost("/admin/apps/{appId}/create", async (
@@ -306,8 +306,6 @@ public static class AppsEndpoints
     public record EnableGenerateSignInTokenEndpointRequest(string PerformedBy);
 
     public record DisableGenerateSignInTokenEndpointRequest(string PerformedBy);
-
-    public record AvailableResponse(bool Available);
 
     public record CancelResult(string Message);
 }

--- a/src/Api/Models/AppAvailable.cs
+++ b/src/Api/Models/AppAvailable.cs
@@ -1,6 +1,0 @@
-namespace Passwordless.Api.Models;
-
-public class AppAvailable
-{
-    public required string AppId { get; set; }
-}

--- a/src/Common/Models/Apps/GetAppIdAvailabilityRequest.cs
+++ b/src/Common/Models/Apps/GetAppIdAvailabilityRequest.cs
@@ -1,0 +1,6 @@
+namespace Passwordless.Common.Models.Apps;
+
+public class GetAppIdAvailabilityRequest
+{
+    public required string AppId { get; set; }
+}

--- a/src/Common/Models/Apps/GetAppIdAvailabilityResponse.cs
+++ b/src/Common/Models/Apps/GetAppIdAvailabilityResponse.cs
@@ -1,0 +1,3 @@
+namespace Passwordless.Common.Models.Apps;
+
+public record GetAppIdAvailabilityResponse(bool Available);

--- a/tests/Api.IntegrationTests/Endpoints/App/AppTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/App/AppTests.cs
@@ -374,6 +374,39 @@ public class AppTests : IClassFixture<PasswordlessApiFactory>, IDisposable
         signInGenerateTokenResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
+    [Fact]
+    public async Task I_can_check_whether_an_app_id_is_available()
+    {
+        // Arrange
+        var applicationName = GetApplicationName();
+
+        // Act
+        using var response = await _client.GetAsync($"/admin/apps/{applicationName}/available");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<GetAppIdAvailabilityResponse>();
+        result.Should().NotBeNull();
+        result!.Available.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task I_can_check_whether_an_app_id_is_unavailable()
+    {
+        // Arrange
+        var applicationName = GetApplicationName();
+        _ = await _client.CreateApplicationAsync(applicationName);
+
+        // Act
+        using var response = await _client.GetAsync($"/admin/apps/{applicationName}/available");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var result = await response.Content.ReadFromJsonAsync<GetAppIdAvailabilityResponse>();
+        result.Should().NotBeNull();
+        result!.Available.Should().BeFalse();
+    }
+
     public void Dispose()
     {
         _client.Dispose();


### PR DESCRIPTION
- Endpoint is now using management key
- Endpoint can no longer be called without authentication to avoid scanning maliciously.
- Admin console uses endpoint protected by session of logged in user using ASP.NET Identity.
- Endpoint moved to match other management key endpoints 'GET /admin/apps/{appId}/available'.
- We will validate appId length client side before considering to call back-end.