### PR TITLE
Add URL-encoding to `PasswordlessManagementClient`

### DIFF
--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
@@ -116,7 +116,7 @@ public class CreateApplicationModel : PageModel
                 MaxUsers = features.MaxUsers,
                 AllowAttestation = features.AllowAttestation
             };
-            res = await _managementClient.CreateApplication(app.Id, newAppOptions);
+            res = await _managementClient.CreateApplicationAsync(app.Id, newAppOptions);
         }
         catch (Exception e)
         {

--- a/src/AdminConsole/Services/ApplicationService.cs
+++ b/src/AdminConsole/Services/ApplicationService.cs
@@ -32,7 +32,7 @@ public class ApplicationService<TDbContext> : IApplicationService where TDbConte
 
     public async Task<MarkDeleteApplicationResponse> MarkApplicationForDeletionAsync(string applicationId, string userName)
     {
-        var response = await _client.MarkDeleteApplication(new MarkDeleteApplicationRequest(applicationId, userName));
+        var response = await _client.MarkDeleteApplicationAsync(new MarkDeleteApplicationRequest(applicationId, userName));
 
         await using var db = await _dbContextFactory.CreateDbContextAsync();
         var application = await db.Applications.FirstOrDefaultAsync(x => x.Id == applicationId);
@@ -57,7 +57,7 @@ public class ApplicationService<TDbContext> : IApplicationService where TDbConte
 
     public async Task CancelDeletionForApplicationAsync(string applicationId)
     {
-        _ = await _client.CancelApplicationDeletion(applicationId);
+        _ = await _client.CancelApplicationDeletionAsync(applicationId);
 
         await using var db = await _dbContextFactory.CreateDbContextAsync();
         var application = await db.Applications

--- a/src/AdminConsole/Services/PasswordlessManagement/IPasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/IPasswordlessManagementClient.cs
@@ -4,10 +4,10 @@ namespace Passwordless.AdminConsole.Services.PasswordlessManagement;
 
 public interface IPasswordlessManagementClient
 {
-    Task<CreateAppResultDto> CreateApplication(string appId, CreateAppDto options);
-    Task<MarkDeleteApplicationResponse> MarkDeleteApplication(MarkDeleteApplicationRequest request);
-    Task<bool> DeleteApplicationAsync(string application);
-    Task<CancelApplicationDeletionResponse> CancelApplicationDeletion(string applicationId);
+    Task<CreateAppResultDto> CreateApplicationAsync(string appId, CreateAppDto options);
+    Task<MarkDeleteApplicationResponse> MarkDeleteApplicationAsync(MarkDeleteApplicationRequest request);
+    Task<bool> DeleteApplicationAsync(string appId);
+    Task<CancelApplicationDeletionResponse> CancelApplicationDeletionAsync(string appId);
     Task<ICollection<string>> ListApplicationsPendingDeletionAsync();
     Task SetFeaturesAsync(string appId, ManageFeaturesRequest request);
     Task<AppFeatureResponse> GetFeaturesAsync(string appId);

--- a/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
@@ -39,8 +39,6 @@ public class PasswordlessManagementClient(HttpClient http) : IPasswordlessManage
     public async Task<bool> DeleteApplicationAsync(string appId)
     {
         using var response = await http.DeleteAsync($"admin/apps/{Uri.EscapeDataString(appId)}");
-        // response.EnsureSuccessStatusCode(); ???
-
         return response.IsSuccessStatusCode;
     }
 

--- a/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
@@ -2,126 +2,160 @@ using Passwordless.Common.Models.Apps;
 
 namespace Passwordless.AdminConsole.Services.PasswordlessManagement;
 
-public class PasswordlessManagementClient : IPasswordlessManagementClient
+public class PasswordlessManagementClient(HttpClient http) : IPasswordlessManagementClient
 {
-    private readonly HttpClient _client;
-
-    public PasswordlessManagementClient(HttpClient client)
+    public async Task<CreateAppResultDto> CreateApplicationAsync(string appId, CreateAppDto options)
     {
-        _client = client;
-    }
+        using var response = await http.PostAsJsonAsync(
+            $"/admin/apps/{Uri.EscapeDataString(appId)}/create",
+            options
+        );
 
-    public async Task<CreateAppResultDto> CreateApplication(string appId, CreateAppDto options)
-    {
-        var res = await _client.PostAsJsonAsync($"/admin/apps/{appId}/create", options);
-        res.EnsureSuccessStatusCode();
-        return await res.Content.ReadFromJsonAsync<CreateAppResultDto>();
-    }
-
-    public async Task<MarkDeleteApplicationResponse> MarkDeleteApplication(MarkDeleteApplicationRequest request)
-    {
-        var response = await _client.PostAsJsonAsync($"admin/apps/{request.AppId}/mark-delete", new { request.DeletedBy });
         response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<CreateAppResultDto>();
+    }
+
+    public async Task<MarkDeleteApplicationResponse> MarkDeleteApplicationAsync(MarkDeleteApplicationRequest request)
+    {
+        using var response = await http.PostAsJsonAsync(
+            $"admin/apps/{Uri.EscapeDataString(request.AppId)}/mark-delete",
+            new { request.DeletedBy }
+        );
+
+        response.EnsureSuccessStatusCode();
+
         return await response.Content.ReadFromJsonAsync<MarkDeleteApplicationResponse>();
     }
 
     public async Task<ICollection<string>> ListApplicationsPendingDeletionAsync()
     {
-        var response = await _client.GetAsync("apps/list-pending-deletion");
+        using var response = await http.GetAsync("apps/list-pending-deletion");
         response.EnsureSuccessStatusCode();
+
         return await response.Content.ReadFromJsonAsync<ICollection<string>>();
     }
 
-    public async Task<bool> DeleteApplicationAsync(string application)
+    public async Task<bool> DeleteApplicationAsync(string appId)
     {
-        var res = await _client.DeleteAsync($"admin/apps/{application}");
-        return res.IsSuccessStatusCode;
+        using var response = await http.DeleteAsync($"admin/apps/{Uri.EscapeDataString(appId)}");
+        // response.EnsureSuccessStatusCode(); ???
+
+        return response.IsSuccessStatusCode;
     }
 
-    public async Task<CancelApplicationDeletionResponse> CancelApplicationDeletion(string applicationId)
+    public async Task<CancelApplicationDeletionResponse> CancelApplicationDeletionAsync(string appId)
     {
-        var response = await _client.PostAsync($"admin/apps/{applicationId}/cancel-delete", null);
+        using var response = await http.PostAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/cancel-delete",
+            null
+        );
+
         response.EnsureSuccessStatusCode();
+
         return await response.Content.ReadFromJsonAsync<CancelApplicationDeletionResponse>();
     }
 
     public async Task SetFeaturesAsync(string appId, ManageFeaturesRequest request)
     {
-        var response = await _client.PostAsJsonAsync($"admin/apps/{appId}/features", request);
+        using var response = await http.PostAsJsonAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/features",
+            request
+        );
+
         response.EnsureSuccessStatusCode();
     }
 
     public async Task<AppFeatureResponse> GetFeaturesAsync(string appId)
     {
-        var response = await _client.GetAsync($"admin/apps/{appId}/features");
+        using var response = await http.GetAsync($"admin/apps/{Uri.EscapeDataString(appId)}/features");
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<AppFeatureResponse>();
-        return result;
+
+        return await response.Content.ReadFromJsonAsync<AppFeatureResponse>();
     }
 
     public async Task<ICollection<ApiKeyResponse>> GetApiKeysAsync(string appId)
     {
-        var response = await _client.GetAsync($"admin/apps/{appId}/api-keys");
+        using var response = await http.GetAsync($"admin/apps/{Uri.EscapeDataString(appId)}/api-keys");
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<ICollection<ApiKeyResponse>>();
-        return result;
+
+        return await response.Content.ReadFromJsonAsync<ICollection<ApiKeyResponse>>();
     }
 
     public async Task<CreateApiKeyResponse> CreateApiKeyAsync(string appId, CreatePublicKeyRequest request)
     {
-        var response = await _client.PostAsJsonAsync($"admin/apps/{appId}/public-keys", request);
+        using var response = await http.PostAsJsonAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/public-keys",
+            request
+        );
+
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
-        return result!;
+
+        return await response.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
     }
 
     public async Task<CreateApiKeyResponse> CreateApiKeyAsync(string appId, CreateSecretKeyRequest request)
     {
-        var response = await _client.PostAsJsonAsync($"admin/apps/{appId}/secret-keys", request);
+        using var response = await http.PostAsJsonAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/secret-keys",
+            request
+        );
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
-        return result!;
+
+        return await response.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
     }
 
     public async Task LockApiKeyAsync(string appId, string apiKeyId)
     {
-        var response = await _client.PostAsync($"admin/apps/{appId}/api-keys/{apiKeyId}/lock", null);
+        using var response = await http.PostAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/api-keys/{Uri.EscapeDataString(apiKeyId)}/lock",
+            null
+        );
+
         response.EnsureSuccessStatusCode();
     }
 
     public async Task UnlockApiKeyAsync(string appId, string apiKeyId)
     {
-        var response = await _client.PostAsync($"admin/apps/{appId}/api-keys/{apiKeyId}/unlock", null);
+        using var response = await http.PostAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/api-keys/{Uri.EscapeDataString(apiKeyId)}/unlock",
+            null
+        );
+
         response.EnsureSuccessStatusCode();
     }
 
     public async Task DeleteApiKeyAsync(string appId, string apiKeyId)
     {
-        var response = await _client.DeleteAsync($"admin/apps/{appId}/api-keys/{apiKeyId}");
+        using var response = await http.DeleteAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/api-keys/{Uri.EscapeDataString(apiKeyId)}"
+        );
+
         response.EnsureSuccessStatusCode();
     }
 
     public async Task EnabledManuallyGeneratedTokensAsync(string appId, string performedBy)
     {
-        var response = await _client.PostAsJsonAsync($"admin/apps/{appId}/sign-in-generate-token-endpoint/enable", new
-        {
-            PerformedBy = performedBy
-        });
+        using var response = await http.PostAsJsonAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/sign-in-generate-token-endpoint/enable",
+            new { PerformedBy = performedBy }
+        );
+
         response.EnsureSuccessStatusCode();
     }
 
     public async Task DisabledManuallyGeneratedTokensAsync(string appId, string performedBy)
     {
-        var response = await _client.PostAsJsonAsync($"admin/apps/{appId}/sign-in-generate-token-endpoint/disable", new
-        {
-            PerformedBy = performedBy
-        });
+        using var response = await http.PostAsJsonAsync(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/sign-in-generate-token-endpoint/disable",
+            new { PerformedBy = performedBy }
+        );
+
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task<GetAppIdAvailabilityResponse> IsApplicationIdAvailableAsync(GetAppIdAvailabilityRequest request)
-    {
-        var response = await _client.GetFromJsonAsync<GetAppIdAvailabilityResponse>($"admin/apps/{request.AppId}/available");
-        return response!;
-    }
+    public async Task<GetAppIdAvailabilityResponse> IsApplicationIdAvailableAsync(GetAppIdAvailabilityRequest request) =>
+        await http.GetFromJsonAsync<GetAppIdAvailabilityResponse>(
+            $"admin/apps/{Uri.EscapeDataString(request.AppId)}/available"
+        );
 }


### PR DESCRIPTION
PAS-314

Also renamed some methods to have the `Async` suffix for consistency with other methods, added `using` to make proper use of the `IDisposable` pattern, and some other minor corrections.