### PR TITLE
Normalize nullability in the database schema

### DIFF
--- a/src/Service/Migrations/Mssql/20240118190159_NormalizeNullability.Designer.cs
+++ b/src/Service/Migrations/Mssql/20240118190159_NormalizeNullability.Designer.cs
@@ -2,54 +2,62 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Passwordless.Service.Storage.Ef;
 
 #nullable disable
 
-namespace Passwordless.Service.Migrations.Sqlite
+namespace Passwordless.Service.Migrations.Mssql
 {
-    [DbContext(typeof(DbGlobalSqliteContext))]
-    partial class SqliteContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(DbGlobalMsSqlContext))]
+    [Migration("20240118190159_NormalizeNullability")]
+    partial class NormalizeNullability
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "8.0.1");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.1")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("Passwordless.Service.EventLog.Models.ApplicationEvent", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ApiKeyId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("EventType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Message")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("PerformedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("PerformedBy")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Severity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Subject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
 
@@ -61,24 +69,24 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.AccountMetaInformation", b =>
                 {
                     b.Property<string>("AcountName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AdminEmailsSerialized")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DeleteAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("SubscriptionTier")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Tenant")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("AcountName");
 
@@ -88,17 +96,17 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.AliasPointer", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Alias")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Plaintext")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "Alias");
 
@@ -108,33 +116,33 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.ApiKeyDesc", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Id")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AccountName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ApiKey")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsLocked")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime?>("LastLockedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("LastUnlockedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Scopes")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "Id");
 
@@ -144,27 +152,27 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.AppFeature", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<bool>("AllowAttestation")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime?>("DeveloperLoggingEndsAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("EventLoggingIsEnabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int>("EventLoggingRetentionPeriod")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("IsGenerateSignInTokenEndpointEnabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(true);
 
                     b.Property<long?>("MaxUsers")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Tenant");
 
@@ -174,70 +182,70 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.EFStoredCredential", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<byte[]>("DescriptorId")
-                        .HasColumnType("BLOB");
+                        .HasColumnType("varbinary(900)");
 
                     b.Property<Guid?>("AaGuid")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("AttestationFmt")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool?>("BackupState")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Country")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("DescriptorTransports")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("DescriptorType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Device")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool?>("IsBackupEligible")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool?>("IsDiscoverable")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime>("LastUsedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Nickname")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Origin")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<byte[]>("PublicKey")
                         .IsRequired()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("varbinary(max)");
 
                     b.Property<string>("RPID")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
-                    b.Property<uint>("SignatureCounter")
-                        .HasColumnType("INTEGER");
+                    b.Property<long>("SignatureCounter")
+                        .HasColumnType("bigint");
 
                     b.Property<byte[]>("UserHandle")
                         .IsRequired()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("varbinary(max)");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "DescriptorId");
 
@@ -247,16 +255,16 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.PeriodicCredentialReport", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateOnly>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("date");
 
                     b.Property<int>("CredentialsCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("UsersCount")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Tenant", "CreatedAt");
 
@@ -266,17 +274,17 @@ namespace Passwordless.Service.Migrations.Sqlite
             modelBuilder.Entity("Passwordless.Service.Models.TokenKey", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("KeyId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("KeyMaterial")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "KeyId");
 

--- a/src/Service/Migrations/Mssql/20240118190159_NormalizeNullability.cs
+++ b/src/Service/Migrations/Mssql/20240118190159_NormalizeNullability.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Passwordless.Service.Migrations.Mssql
+{
+    /// <inheritdoc />
+    public partial class NormalizeNullability : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "KeyMaterial",
+                table: "TokenKeys",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "UserHandle",
+                table: "Credentials",
+                type: "varbinary(max)",
+                nullable: false,
+                defaultValue: new byte[0],
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RPID",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "PublicKey",
+                table: "Credentials",
+                type: "varbinary(max)",
+                nullable: false,
+                defaultValue: new byte[0],
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Origin",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AttestationFmt",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "AaGuid",
+                table: "Credentials",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Scopes",
+                table: "ApiKeys",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApiKey",
+                table: "ApiKeys",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Aliases",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Tenant",
+                table: "AccountInfo",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AdminEmailsSerialized",
+                table: "AccountInfo",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "KeyMaterial",
+                table: "TokenKeys",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "UserHandle",
+                table: "Credentials",
+                type: "varbinary(max)",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RPID",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "PublicKey",
+                table: "Credentials",
+                type: "varbinary(max)",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Origin",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AttestationFmt",
+                table: "Credentials",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "AaGuid",
+                table: "Credentials",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Scopes",
+                table: "ApiKeys",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApiKey",
+                table: "ApiKeys",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Aliases",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Tenant",
+                table: "AccountInfo",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AdminEmailsSerialized",
+                table: "AccountInfo",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/src/Service/Migrations/Mssql/20240118190159_NormalizeNullability.cs
+++ b/src/Service/Migrations/Mssql/20240118190159_NormalizeNullability.cs
@@ -1,253 +1,251 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Passwordless.Service.Migrations.Mssql
+namespace Passwordless.Service.Migrations.Mssql;
+
+/// <inheritdoc />
+public partial class NormalizeNullability : Migration
 {
     /// <inheritdoc />
-    public partial class NormalizeNullability : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<string>(
-                name: "KeyMaterial",
-                table: "TokenKeys",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "KeyMaterial",
+            table: "TokenKeys",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "UserHandle",
-                table: "Credentials",
-                type: "varbinary(max)",
-                nullable: false,
-                defaultValue: new byte[0],
-                oldClrType: typeof(byte[]),
-                oldType: "varbinary(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "UserHandle",
+            table: "Credentials",
+            type: "varbinary(max)",
+            nullable: false,
+            defaultValue: new byte[0],
+            oldClrType: typeof(byte[]),
+            oldType: "varbinary(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "RPID",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "RPID",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "PublicKey",
-                table: "Credentials",
-                type: "varbinary(max)",
-                nullable: false,
-                defaultValue: new byte[0],
-                oldClrType: typeof(byte[]),
-                oldType: "varbinary(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "PublicKey",
+            table: "Credentials",
+            type: "varbinary(max)",
+            nullable: false,
+            defaultValue: new byte[0],
+            oldClrType: typeof(byte[]),
+            oldType: "varbinary(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Origin",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "Origin",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AttestationFmt",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "AttestationFmt",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "AaGuid",
-                table: "Credentials",
-                type: "uniqueidentifier",
-                nullable: true,
-                oldClrType: typeof(Guid),
-                oldType: "uniqueidentifier");
+        migrationBuilder.AlterColumn<Guid>(
+            name: "AaGuid",
+            table: "Credentials",
+            type: "uniqueidentifier",
+            nullable: true,
+            oldClrType: typeof(Guid),
+            oldType: "uniqueidentifier");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Scopes",
-                table: "ApiKeys",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "Scopes",
+            table: "ApiKeys",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "ApiKey",
-                table: "ApiKeys",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "ApiKey",
+            table: "ApiKeys",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Aliases",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Aliases",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Tenant",
-                table: "AccountInfo",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "Tenant",
+            table: "AccountInfo",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AdminEmailsSerialized",
-                table: "AccountInfo",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldNullable: true);
-        }
+        migrationBuilder.AlterColumn<string>(
+            name: "AdminEmailsSerialized",
+            table: "AccountInfo",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldNullable: true);
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<string>(
-                name: "KeyMaterial",
-                table: "TokenKeys",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "KeyMaterial",
+            table: "TokenKeys",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "UserHandle",
-                table: "Credentials",
-                type: "varbinary(max)",
-                nullable: true,
-                oldClrType: typeof(byte[]),
-                oldType: "varbinary(max)");
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "UserHandle",
+            table: "Credentials",
+            type: "varbinary(max)",
+            nullable: true,
+            oldClrType: typeof(byte[]),
+            oldType: "varbinary(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "RPID",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "RPID",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "PublicKey",
-                table: "Credentials",
-                type: "varbinary(max)",
-                nullable: true,
-                oldClrType: typeof(byte[]),
-                oldType: "varbinary(max)");
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "PublicKey",
+            table: "Credentials",
+            type: "varbinary(max)",
+            nullable: true,
+            oldClrType: typeof(byte[]),
+            oldType: "varbinary(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Origin",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "Origin",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AttestationFmt",
-                table: "Credentials",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "AttestationFmt",
+            table: "Credentials",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "AaGuid",
-                table: "Credentials",
-                type: "uniqueidentifier",
-                nullable: false,
-                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
-                oldClrType: typeof(Guid),
-                oldType: "uniqueidentifier",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<Guid>(
+            name: "AaGuid",
+            table: "Credentials",
+            type: "uniqueidentifier",
+            nullable: false,
+            defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+            oldClrType: typeof(Guid),
+            oldType: "uniqueidentifier",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Scopes",
-                table: "ApiKeys",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "Scopes",
+            table: "ApiKeys",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "ApiKey",
-                table: "ApiKeys",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "ApiKey",
+            table: "ApiKeys",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Aliases",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Aliases",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Tenant",
-                table: "AccountInfo",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "Tenant",
+            table: "AccountInfo",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AdminEmailsSerialized",
-                table: "AccountInfo",
-                type: "nvarchar(max)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
-        }
+        migrationBuilder.AlterColumn<string>(
+            name: "AdminEmailsSerialized",
+            table: "AccountInfo",
+            type: "nvarchar(max)",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
     }
 }

--- a/src/Service/Migrations/Mssql/MsSqlContextModelSnapshot.cs
+++ b/src/Service/Migrations/Mssql/MsSqlContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace Passwordless.Service.Migrations.Mssql
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("ProductVersion", "8.0.1")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -69,6 +69,7 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AdminEmailsSerialized")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
@@ -81,6 +82,7 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Tenant")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("AcountName");
@@ -100,6 +102,7 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("UserId")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "Alias");
@@ -119,6 +122,7 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ApiKey")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
@@ -134,6 +138,7 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("datetime2");
 
                     b.Property<string>("Scopes")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "Id");
@@ -179,10 +184,11 @@ namespace Passwordless.Service.Migrations.Mssql
                     b.Property<byte[]>("DescriptorId")
                         .HasColumnType("varbinary(900)");
 
-                    b.Property<Guid>("AaGuid")
+                    b.Property<Guid?>("AaGuid")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("AttestationFmt")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<bool?>("BackupState")
@@ -216,21 +222,26 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Origin")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<byte[]>("PublicKey")
+                        .IsRequired()
                         .HasColumnType("varbinary(max)");
 
                     b.Property<string>("RPID")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("SignatureCounter")
                         .HasColumnType("bigint");
 
                     b.Property<byte[]>("UserHandle")
+                        .IsRequired()
                         .HasColumnType("varbinary(max)");
 
                     b.Property<string>("UserId")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "DescriptorId");
@@ -269,6 +280,7 @@ namespace Passwordless.Service.Migrations.Mssql
                         .HasColumnType("datetime2");
 
                     b.Property<string>("KeyMaterial")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Tenant", "KeyId");

--- a/src/Service/Migrations/Sqlite/20240118190130_NormalizeNullability.Designer.cs
+++ b/src/Service/Migrations/Sqlite/20240118190130_NormalizeNullability.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Passwordless.Service.Storage.Ef;
 
@@ -10,9 +11,11 @@ using Passwordless.Service.Storage.Ef;
 namespace Passwordless.Service.Migrations.Sqlite
 {
     [DbContext(typeof(DbGlobalSqliteContext))]
-    partial class SqliteContextModelSnapshot : ModelSnapshot
+    [Migration("20240118190130_NormalizeNullability")]
+    partial class NormalizeNullability
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.1");

--- a/src/Service/Migrations/Sqlite/20240118190130_NormalizeNullability.cs
+++ b/src/Service/Migrations/Sqlite/20240118190130_NormalizeNullability.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Passwordless.Service.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    public partial class NormalizeNullability : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "KeyMaterial",
+                table: "TokenKeys",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "UserHandle",
+                table: "Credentials",
+                type: "BLOB",
+                nullable: false,
+                defaultValue: new byte[0],
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RPID",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "PublicKey",
+                table: "Credentials",
+                type: "BLOB",
+                nullable: false,
+                defaultValue: new byte[0],
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Origin",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AttestationFmt",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "AaGuid",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Scopes",
+                table: "ApiKeys",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApiKey",
+                table: "ApiKeys",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Aliases",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Tenant",
+                table: "AccountInfo",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AdminEmailsSerialized",
+                table: "AccountInfo",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "KeyMaterial",
+                table: "TokenKeys",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "UserHandle",
+                table: "Credentials",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RPID",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "PublicKey",
+                table: "Credentials",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Origin",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AttestationFmt",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "AaGuid",
+                table: "Credentials",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Scopes",
+                table: "ApiKeys",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApiKey",
+                table: "ApiKeys",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Aliases",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Tenant",
+                table: "AccountInfo",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AdminEmailsSerialized",
+                table: "AccountInfo",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+        }
+    }
+}

--- a/src/Service/Migrations/Sqlite/20240118190130_NormalizeNullability.cs
+++ b/src/Service/Migrations/Sqlite/20240118190130_NormalizeNullability.cs
@@ -1,253 +1,251 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Passwordless.Service.Migrations.Sqlite
+namespace Passwordless.Service.Migrations.Sqlite;
+
+/// <inheritdoc />
+public partial class NormalizeNullability : Migration
 {
     /// <inheritdoc />
-    public partial class NormalizeNullability : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<string>(
-                name: "KeyMaterial",
-                table: "TokenKeys",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "KeyMaterial",
+            table: "TokenKeys",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "UserHandle",
-                table: "Credentials",
-                type: "BLOB",
-                nullable: false,
-                defaultValue: new byte[0],
-                oldClrType: typeof(byte[]),
-                oldType: "BLOB",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "UserHandle",
+            table: "Credentials",
+            type: "BLOB",
+            nullable: false,
+            defaultValue: new byte[0],
+            oldClrType: typeof(byte[]),
+            oldType: "BLOB",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "RPID",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "RPID",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "PublicKey",
-                table: "Credentials",
-                type: "BLOB",
-                nullable: false,
-                defaultValue: new byte[0],
-                oldClrType: typeof(byte[]),
-                oldType: "BLOB",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "PublicKey",
+            table: "Credentials",
+            type: "BLOB",
+            nullable: false,
+            defaultValue: new byte[0],
+            oldClrType: typeof(byte[]),
+            oldType: "BLOB",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Origin",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "Origin",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AttestationFmt",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "AttestationFmt",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "AaGuid",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(Guid),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<Guid>(
+            name: "AaGuid",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(Guid),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Scopes",
-                table: "ApiKeys",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "Scopes",
+            table: "ApiKeys",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "ApiKey",
-                table: "ApiKeys",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "ApiKey",
+            table: "ApiKeys",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Aliases",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Aliases",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Tenant",
-                table: "AccountInfo",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<string>(
+            name: "Tenant",
+            table: "AccountInfo",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AdminEmailsSerialized",
-                table: "AccountInfo",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: "",
-                oldClrType: typeof(string),
-                oldType: "TEXT",
-                oldNullable: true);
-        }
+        migrationBuilder.AlterColumn<string>(
+            name: "AdminEmailsSerialized",
+            table: "AccountInfo",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<string>(
-                name: "KeyMaterial",
-                table: "TokenKeys",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "KeyMaterial",
+            table: "TokenKeys",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "UserHandle",
-                table: "Credentials",
-                type: "BLOB",
-                nullable: true,
-                oldClrType: typeof(byte[]),
-                oldType: "BLOB");
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "UserHandle",
+            table: "Credentials",
+            type: "BLOB",
+            nullable: true,
+            oldClrType: typeof(byte[]),
+            oldType: "BLOB");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "RPID",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "RPID",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<byte[]>(
-                name: "PublicKey",
-                table: "Credentials",
-                type: "BLOB",
-                nullable: true,
-                oldClrType: typeof(byte[]),
-                oldType: "BLOB");
+        migrationBuilder.AlterColumn<byte[]>(
+            name: "PublicKey",
+            table: "Credentials",
+            type: "BLOB",
+            nullable: true,
+            oldClrType: typeof(byte[]),
+            oldType: "BLOB");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Origin",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "Origin",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AttestationFmt",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "AttestationFmt",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "AaGuid",
-                table: "Credentials",
-                type: "TEXT",
-                nullable: false,
-                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
-                oldClrType: typeof(Guid),
-                oldType: "TEXT",
-                oldNullable: true);
+        migrationBuilder.AlterColumn<Guid>(
+            name: "AaGuid",
+            table: "Credentials",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+            oldClrType: typeof(Guid),
+            oldType: "TEXT",
+            oldNullable: true);
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Scopes",
-                table: "ApiKeys",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "Scopes",
+            table: "ApiKeys",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "ApiKey",
-                table: "ApiKeys",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "ApiKey",
+            table: "ApiKeys",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "UserId",
-                table: "Aliases",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "UserId",
+            table: "Aliases",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Tenant",
-                table: "AccountInfo",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
+        migrationBuilder.AlterColumn<string>(
+            name: "Tenant",
+            table: "AccountInfo",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "AdminEmailsSerialized",
-                table: "AccountInfo",
-                type: "TEXT",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "TEXT");
-        }
+        migrationBuilder.AlterColumn<string>(
+            name: "AdminEmailsSerialized",
+            table: "AccountInfo",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
     }
 }


### PR DESCRIPTION
#340 fixed nullability annotations in database models, but didn't include migrations to normalize them in the database schema. This PR fixes that.