### PR TITLE
Fix pin reference for HTTP request action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Send Slack message
-        uses: tyrrrz/action-http-request@64c70c67f5ebc54d4c7ea09cbe3553322778afd5 # v1.1.2
+        uses: tyrrrz/action-http-request@64c70c67f5ebc54d4c7ea09cbe3553322778afd5 # 1.1.2
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
           method: POST


### PR DESCRIPTION
Renovate relies on these comments to match hashes to tags, but this action doesn't prepend tags with `v` like the other actions.