### PR TITLE
Lowering Admin Page rate limit

### DIFF
--- a/src/AdminConsole/RateLimiting/AdminPageRateLimit.cs
+++ b/src/AdminConsole/RateLimiting/AdminPageRateLimit.cs
@@ -7,7 +7,7 @@ namespace Passwordless.AdminConsole.RateLimiting;
 public static class AdminPageRateLimit
 {
     public const string PolicyName = "organizationIdFixedLength";
-    private const int PermitLimit = 100;
+    private const int PermitLimit = 50;
     private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
     private const int QueueLimit = 0;
 


### PR DESCRIPTION
Lowering this limit to 50 to reduce ability to send out spam emails.  This would cover the case of sending then canceling the same email address over and over again.  It takes roughly 5 requests for the steps of loading the page, sending the page, then canceling the invite.  So to limit to 10 per minute, we would set the request limit to 50.