### PR TITLE
Ignore `Datadog.Trace` in Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,5 +36,6 @@
       "matchManagers": ["nuget"],
       "matchUpdateTypes": ["minor", "patch"]
     }
-  ]
+  ],
+  "ignoreDeps": ["Datadog.Trace"]
 }


### PR DESCRIPTION
This package has to be in-sync with the version of the agent we use in Azure, so we need to update it manually.

Docs reference: https://docs.renovatebot.com/configuration-options/#ignoredeps

Related: https://github.com/bitwarden/passwordless-server/pull/369