### PR TITLE
Using existing record to cancel invite

### DIFF
--- a/src/AdminConsole/Pages/Organization/Admins.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/Admins.cshtml.cs
@@ -139,7 +139,7 @@ public class Admins : PageModel
 
         if (inviteToCancel is null)
         {
-            ModelState.AddModelError("error", "Could not cancel because invite could not be found.");
+            ModelState.AddModelError("error", "Failed to find an invite to cancel.");
             return await OnGet();
         }
 

--- a/src/AdminConsole/Pages/Organization/Admins.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/Admins.cshtml.cs
@@ -143,7 +143,7 @@ public class Admins : PageModel
             return await OnGet();
         }
 
-        await _invitationService.CancelInviteAsync(inviteToCancel.HashedCode);
+        await _invitationService.CancelInviteAsync(inviteToCancel);
 
         var performedBy = await _dataService.GetUserAsync();
 

--- a/src/AdminConsole/RateLimiting/AdminPageRateLimit.cs
+++ b/src/AdminConsole/RateLimiting/AdminPageRateLimit.cs
@@ -7,7 +7,7 @@ namespace Passwordless.AdminConsole.RateLimiting;
 public static class AdminPageRateLimit
 {
     public const string PolicyName = "organizationIdFixedLength";
-    private const int PermitLimit = 100;
+    private const int PermitLimit = 50;
     private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
     private const int QueueLimit = 0;
 

--- a/src/AdminConsole/Services/IInvitationService.cs
+++ b/src/AdminConsole/Services/IInvitationService.cs
@@ -6,7 +6,7 @@ public interface IInvitationService
 {
     Task SendInviteAsync(string toEmail, int targetOrgId, string targetOrgName, string fromEmail, string fromName);
     Task<List<Invite>> GetInvitesAsync(int orgId);
-    Task CancelInviteAsync(string hashedCode);
+    Task CancelInviteAsync(Invite inviteToCancel);
     Task<Invite> GetInviteFromRawCodeAsync(string code);
     Task<bool> ConsumeInviteAsync(Invite inv);
 }

--- a/src/AdminConsole/Services/InvitationService.cs
+++ b/src/AdminConsole/Services/InvitationService.cs
@@ -73,10 +73,10 @@ public class InvitationService<TDbContext> : IInvitationService where TDbContext
         return await db.Invites.Where(i => i.TargetOrgId == orgId).ToListAsync();
     }
 
-    public async Task CancelInviteAsync(string hashedCode)
+    public async Task CancelInviteAsync(Invite inviteToCancel)
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync();
-        await db.Invites.Where(i => i.HashedCode == hashedCode).ExecuteDeleteAsync();
+        await db.Invites.Where(i => i.HashedCode == inviteToCancel.HashedCode).ExecuteDeleteAsync();
     }
 
     public async Task<Invite> GetInviteFromRawCodeAsync(string code)


### PR DESCRIPTION
Added some error messaging in the event a non-existent hash is passed in. Also, using the existing invite to cancel instead of passing the hashedcode through.