### PR TITLE
Fixed Attestation link size to match other "buttons"

### DIFF
--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml
@@ -89,7 +89,7 @@
     <panel header="Attestation">
         <p>When attestation is enabled, you can choose to limit the authenticators used with your application.</p>
         
-        <div class="flex">
+        <div>
             <a class="btn-primary" href="/app/@Model.ApplicationId/settings/authenticators">View authenticators</a>
         </div>
     </panel>

--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml
@@ -89,7 +89,7 @@
     <panel header="Attestation">
         <p>When attestation is enabled, you can choose to limit the authenticators used with your application.</p>
         
-        <div>
+        <div class="flex">
             <a class="btn-primary" href="/app/@Model.ApplicationId/settings/authenticators">View authenticators</a>
         </div>
     </panel>

--- a/src/AdminConsole/Styles/tailwind.css
+++ b/src/AdminConsole/Styles/tailwind.css
@@ -23,7 +23,7 @@
     }
 
     .btn {
-        @apply rounded py-1 px-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
+        @apply rounded py-1 px-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 inline-block;
     }
 
     .btn-primary {


### PR DESCRIPTION
Added `inline-block` to `btn` so that buttons have the same uniform size.

Before:
![image](https://github.com/bitwarden/passwordless-server/assets/7258973/0e609d8b-be28-4fd7-a00f-640458505e70)

After:
![image](https://github.com/bitwarden/passwordless-server/assets/7258973/89a020fc-c76f-41c3-9771-f88c883c6e30)
