### PR TITLE
UI prompt does not make sense when no plans are shown

### DIFF
--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml
@@ -52,6 +52,7 @@
                         </li>
                     }
                 </ul>
+                <info-alert-box variant="ColorVariant.Info" message="The application can always be assigned to a different plan later in the 'Billing' section."></info-alert-box>
             </div>
             <input asp-if="!Model.Organization.HasSubscription" type="hidden" asp-for="Form.Plan" />
 
@@ -62,10 +63,6 @@
                         class="flex w-full justify-center rounded-md bg-primary-500 py-2 px-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
                     Create
                 </button>
-            </div>
-            
-            <div>
-                <info-alert-box variant="ColorVariant.Info" message="The application can always be assigned to a different plan later in the 'Billing' section."></info-alert-box>
             </div>
         </form>
     </div>


### PR DESCRIPTION
<img width="2056" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/6d96a231-fbdc-4aaf-bb9e-7a0172d19242">

<img width="2056" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/2e5dec43-45f9-4b65-aaf2-f54131721df4">
