### PR TITLE
Charts for Users and Credentials y-axis should be whole numbers

### DIFF
--- a/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalCredentialsCountChart.razor
+++ b/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalCredentialsCountChart.razor
@@ -1,7 +1,7 @@
 @using Passwordless.Common.Models.Reporting
 @using Passwordless.AdminConsole.Components.Shared.ApexCharts.Models
 
-<ApexChart Id="total-credentials-count-chart" Options="_options" />
+<ApexChart Id="total-credentials-count-chart" Options="_options" YAxisFormatting="LabelsFormattingTypes.Integer" />
 
 @code {
     [Parameter] public required IEnumerable<PeriodicCredentialReportResponse> Data { get; set; }

--- a/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalUsersCountChart.razor
+++ b/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalUsersCountChart.razor
@@ -1,7 +1,7 @@
 @using Passwordless.Common.Models.Reporting
 @using Passwordless.AdminConsole.Components.Shared.ApexCharts.Models
 
-<ApexChart Id="total-users-count-chart" Options="_options" />
+<ApexChart Id="total-users-count-chart" Options="_options" YAxisFormatting="LabelsFormattingTypes.Integer" />
 
 @code {
     [Parameter]

--- a/src/AdminConsole/Components/Shared/ApexCharts/ApexChart.razor
+++ b/src/AdminConsole/Components/Shared/ApexCharts/ApexChart.razor
@@ -8,6 +8,16 @@
 
 <SecureScript type="module">
     let options = @((MarkupString)JsonSerializer.Serialize(Options, ApexChartJsonSerializer.Options));
+    
+    @switch (YAxisFormatting) {
+        case LabelsFormattingTypes.Integer:
+            @((MarkupString)"options.yaxis.labels.formatter = (value) => parseInt(value).toLocaleString();")
+            break;
+        case LabelsFormattingTypes.Double:
+            @((MarkupString)"options.yaxis.labels.formatter = (value) => parseFloat(value).toFixed(2).toLocaleString();")
+            break;
+    }
+    
     let chart = new ApexCharts(document.querySelector("#@Id"), options);    
     chart.render();
 </SecureScript>
@@ -19,4 +29,7 @@
     
     [Parameter]
     public required ApexChartOptions<TXValueType, TYValueType> Options { get; set; }
+    
+    [Parameter]
+    public LabelsFormattingTypes? YAxisFormatting { get; set; }
 }

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/ApexChartOptions.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/ApexChartOptions.cs
@@ -12,6 +12,8 @@ public class ApexChartOptions<TXValueType, TYValueType>
 
     public Xaxis<TXValueType>? Xaxis { get; set; }
 
+    public Yaxis Yaxis { get; } = new();
+
     public NoData NoData { get; set; } = new();
 
     public Legend Legend { get; set; } = new();

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/LabelsFormattingTypes.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/LabelsFormattingTypes.cs
@@ -1,0 +1,8 @@
+namespace Passwordless.AdminConsole.Components.Shared.ApexCharts.Models;
+
+public enum LabelsFormattingTypes
+{
+    Integer,
+    Double,
+    DateTime
+}

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/Yaxis.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/Yaxis.cs
@@ -1,0 +1,6 @@
+namespace Passwordless.AdminConsole.Components.Shared.ApexCharts.Models;
+
+public class Yaxis
+{
+    public YaxisLabels Labels { get; } = new();
+}

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/YaxisLabels.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/YaxisLabels.cs
@@ -1,0 +1,5 @@
+namespace Passwordless.AdminConsole.Components.Shared.ApexCharts.Models;
+
+public class YaxisLabels
+{
+}


### PR DESCRIPTION
<img width="747" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/e1ad96e7-9e20-4145-82d0-2e06e6e74168">

Both charts use integers for Y-axis. Just demonstrating with floats to demonstrate the code is working as intended.

Attempted to serialize the anonymous function with system.text.json, but seems to have safeguards in place. Inline was the only way to go.