### PR TITLE
Primary constructors are not ready yet.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -89,6 +89,8 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 #### C# Coding Conventions ####
 [*.cs]
 
+csharp_style_prefer_primary_constructors = false
+
 # var preferences
 csharp_style_var_elsewhere = false:silent
 csharp_style_var_for_built_in_types = true:silent
@@ -393,3 +395,4 @@ dotnet_naming_style.s_camelcase.capitalization = camel_case
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_allow_multiple_blank_lines_experimental = true:silent
 dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+


### PR DESCRIPTION
The syntax of primary constructors does not seem right with classes, and should possibly be avoided. Having to prepend `this.` everywhere just seems like a step back. `camelCase` syntax should be preserved for local variables, parameters, etc.