### PR TITLE
Soften the logging level when user is not found.

### DIFF
--- a/src/AdminConsole/Pages/Account/Login.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/Login.cshtml.cs
@@ -37,6 +37,7 @@ public class LoginModel : PageModel
     {
         returnUrl = Url.Page("/Organization/Overview");
 
+
         try
         {
             // send magic link if we have a user like it

--- a/src/AdminConsole/Services/MagicLinks/MagicLinkSignInManager.cs
+++ b/src/AdminConsole/Services/MagicLinks/MagicLinkSignInManager.cs
@@ -34,10 +34,16 @@ public class MagicLinkSignInManager<TUser> : SignInManager<TUser> where TUser : 
 
     public async Task<SignInResult> SendEmailForSignInAsync(string email, string? returnUrl)
     {
+        var user = await UserManager.FindByEmailAsync(email);
+        if (user == null)
+        {
+            Logger.LogInformation("User {email} not found.", email);
+            return SignInResult.Failed;
+        }
+
         var magicLink = await _magicLinkBuilder.GetLinkAsync(email, returnUrl);
         await _mailService.SendPasswordlessSignInAsync(magicLink, email);
 
-        var user = await UserManager.FindByEmailAsync(email);
         if (user is ConsoleAdmin admin)
             _eventLogger.LogCreateLoginViaMagicLinkEvent(admin);
 


### PR DESCRIPTION
Depending on the MagicLinkBuilder to throw an exception seems like a bad idea. So we check early whether the user is null, and return signin as failed accordingly.