### PR TITLE
Exclude health checks from event logging

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Passwordless.AspNetCore" Version="2.0.0-beta5" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+    <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     <PackageReference Include="Stripe.net" Version="41.*" />

--- a/src/AdminConsole/appsettings.json
+++ b/src/AdminConsole/appsettings.json
@@ -7,7 +7,15 @@
         "Microsoft.Hosting.Lifetime": "Information",
         "System": "Warning"
       }
-    }
+    },
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "Contains(RequestPath, '/health/') and StatusCode=200"
+        }
+      }
+    ]
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="MinimalApis.Extensions" Version="0.11.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
       <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+      <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
       <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />
       <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
       <PackageReference Include="UAParser" Version="3.1.47" />

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -7,7 +7,15 @@
         "Microsoft.Hosting.Lifetime": "Information",
         "System": "Warning"
       }
-    }
+    },
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "Contains(RequestPath, '/health/') and StatusCode=200"
+        }
+      }
+    ]
   },
   "AllowedHosts": "*",
   "SALT_TOKEN":  "",


### PR DESCRIPTION
If the path contains `/health/`, we can exclude request logging when it is successful. We still want to capture failed requests.