### PR TITLE
PAS 371 - Change token template

### DIFF
--- a/src/Service/MagicLinks/MagicLinkService.cs
+++ b/src/Service/MagicLinks/MagicLinkService.cs
@@ -80,7 +80,7 @@ public class MagicLinkService(
         await EnforceQuotaAsync(dto);
 
         var token = await fido2Service.CreateSigninToken(new SigninTokenRequest(dto.UserId));
-        var link = new Uri(dto.LinkTemplate.Replace("<token>", token));
+        var link = new Uri(dto.LinkTemplate.Replace(SendMagicLinkRequest.TokenTemplate, token));
 
         await mailProvider.SendAsync(new MailMessage
         {

--- a/src/Service/MagicLinks/Models/SendMagicLinkRequest.cs
+++ b/src/Service/MagicLinks/Models/SendMagicLinkRequest.cs
@@ -6,6 +6,8 @@ namespace Passwordless.Service.MagicLinks.Models;
 
 public class SendMagicLinkRequest
 {
+    public const string TokenTemplate = "__TOKEN__";
+
     [Required]
     [EmailAddress]
     public string EmailAddress { get; init; }

--- a/src/Service/MagicLinks/Models/SendMagicLinkRequest.cs
+++ b/src/Service/MagicLinks/Models/SendMagicLinkRequest.cs
@@ -6,7 +6,7 @@ namespace Passwordless.Service.MagicLinks.Models;
 
 public class SendMagicLinkRequest
 {
-    public const string TokenTemplate = "__TOKEN__";
+    public const string TokenTemplate = "$TOKEN";
 
     [Required]
     [EmailAddress]

--- a/src/Service/MagicLinks/Models/SendMagicLinkRequest.cs
+++ b/src/Service/MagicLinks/Models/SendMagicLinkRequest.cs
@@ -11,7 +11,7 @@ public class SendMagicLinkRequest
     public string EmailAddress { get; init; }
 
     [Required]
-    [MagicLinkTemplateUrlAttribute]
+    [MagicLinkTemplateUrl]
     public string UrlTemplate { get; init; }
 
     [Required]

--- a/src/Service/MagicLinks/Validation/MagicLinkUrlTemplateAttribute.cs
+++ b/src/Service/MagicLinks/Validation/MagicLinkUrlTemplateAttribute.cs
@@ -5,7 +5,7 @@ namespace Passwordless.Service.MagicLinks.Validation;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class MagicLinkTemplateUrlAttribute : ValidationAttribute
 {
-    private const string TokenTemplate = "<token>";
+    private const string TokenTemplate = "__TOKEN__";
 
     protected override ValidationResult IsValid(object value, ValidationContext validationContext)
     {
@@ -13,7 +13,7 @@ public class MagicLinkTemplateUrlAttribute : ValidationAttribute
             return new ValidationResult($"You have provided a null or empty value for {validationContext.MemberName}.");
 
         if (!stringValue.Contains(TokenTemplate))
-            return new ValidationResult($"You have provided a {validationContext.MemberName} without a {TokenTemplate} template. Please include it like so: https://www.example.com?token=<token>");
+            return new ValidationResult($"You have provided a {validationContext.MemberName} without a {TokenTemplate} template. Please include it like so: https://www.example.com?token=__TOKEN__");
 
         if (!(Uri.TryCreate(stringValue, UriKind.Absolute, out var uriResult)
               && (uriResult.Scheme == Uri.UriSchemeHttp

--- a/src/Service/MagicLinks/Validation/MagicLinkUrlTemplateAttribute.cs
+++ b/src/Service/MagicLinks/Validation/MagicLinkUrlTemplateAttribute.cs
@@ -1,19 +1,18 @@
 using System.ComponentModel.DataAnnotations;
+using Passwordless.Service.MagicLinks.Models;
 
 namespace Passwordless.Service.MagicLinks.Validation;
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class MagicLinkTemplateUrlAttribute : ValidationAttribute
 {
-    private const string TokenTemplate = "__TOKEN__";
-
     protected override ValidationResult IsValid(object value, ValidationContext validationContext)
     {
         if (value is not string stringValue || string.IsNullOrWhiteSpace(stringValue))
             return new ValidationResult($"You have provided a null or empty value for {validationContext.MemberName}.");
 
-        if (!stringValue.Contains(TokenTemplate))
-            return new ValidationResult($"You have provided a {validationContext.MemberName} without a {TokenTemplate} template. Please include it like so: https://www.example.com?token=__TOKEN__");
+        if (!stringValue.Contains(SendMagicLinkRequest.TokenTemplate))
+            return new ValidationResult($"You have provided a {validationContext.MemberName} without a {SendMagicLinkRequest.TokenTemplate} template. Please include it like so: https://www.example.com?token={SendMagicLinkRequest.TokenTemplate}");
 
         if (!(Uri.TryCreate(stringValue, UriKind.Absolute, out var uriResult)
               && (uriResult.Scheme == Uri.UriSchemeHttp

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -93,7 +93,7 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         responseDetails.Should().NotBeNull();
         var magicLinkUrlError = responseDetails!.Errors.FirstOrDefault(x => x.Key.Equals(nameof(request.UrlTemplate), StringComparison.CurrentCultureIgnoreCase));
         magicLinkUrlError.Should().NotBeNull();
-        magicLinkUrlError.Value.Should().Contain($"You have provided a {nameof(request.UrlTemplate)} without a __TOKEN__ template. Please include it like so: https://www.example.com?token=__TOKEN__");
+        magicLinkUrlError.Value.Should().Contain($"You have provided a {nameof(request.UrlTemplate)} without a {SendMagicLinkRequest.TokenTemplate} template. Please include it like so: https://www.example.com?token={SendMagicLinkRequest.TokenTemplate}");
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         client.AddSecretKey(appCreated!.ApiSecret1);
         await client.EnableMagicLinks("a_user");
         var request = _requestFaker
-            .RuleFor(x => x.UrlTemplate, () => "__TOKEN__")
+            .RuleFor(x => x.UrlTemplate, () => SendMagicLinkRequest.TokenTemplate)
             .Generate();
 
         // Skip all limitations for new applications

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -93,7 +93,7 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         responseDetails.Should().NotBeNull();
         var magicLinkUrlError = responseDetails!.Errors.FirstOrDefault(x => x.Key.Equals(nameof(request.UrlTemplate), StringComparison.CurrentCultureIgnoreCase));
         magicLinkUrlError.Should().NotBeNull();
-        magicLinkUrlError.Value.Should().Contain($"You have provided a {nameof(request.UrlTemplate)} without a <token> template. Please include it like so: https://www.example.com?token=<token>");
+        magicLinkUrlError.Value.Should().Contain($"You have provided a {nameof(request.UrlTemplate)} without a __TOKEN__ template. Please include it like so: https://www.example.com?token=__TOKEN__");
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         client.AddSecretKey(appCreated!.ApiSecret1);
         await client.EnableMagicLinks("a_user");
         var request = _requestFaker
-            .RuleFor(x => x.UrlTemplate, () => "<token>")
+            .RuleFor(x => x.UrlTemplate, () => "__TOKEN__")
             .Generate();
 
         // Skip all limitations for new applications

--- a/tests/Api.IntegrationTests/Helpers/App/RequestHelpers.cs
+++ b/tests/Api.IntegrationTests/Helpers/App/RequestHelpers.cs
@@ -9,7 +9,7 @@ public static class RequestHelpers
     public static Faker<SendMagicLinkRequest> GetMagicLinkRequestRules() => new Faker<SendMagicLinkRequest>()
         .RuleFor(x => x.UserId, () => Guid.NewGuid().ToString())
         .RuleFor(x => x.EmailAddress, faker => faker.Person.Email)
-        .RuleFor(x => x.UrlTemplate, faker => $"{faker.Internet.Url()}?token=<token>");
+        .RuleFor(x => x.UrlTemplate, faker => $"{faker.Internet.Url()}?token=__TOKEN__");
 
     public static Faker<RegisterToken> GetRegisterTokenGeneratorRules() => new Faker<RegisterToken>()
         .RuleFor(x => x.UserId, Guid.NewGuid().ToString())
@@ -18,7 +18,7 @@ public static class RequestHelpers
         .RuleFor(x => x.Attestation, "None")
         .RuleFor(x => x.Discoverable, true)
         .RuleFor(x => x.UserVerification, "Preferred")
-        .RuleFor(x => x.Aliases, x => new HashSet<string> { x.Person.FirstName })
+        .RuleFor(x => x.Aliases, x => [x.Person.FirstName])
         .RuleFor(x => x.AliasHashing, false)
         .RuleFor(x => x.ExpiresAt, DateTime.UtcNow.AddDays(1))
         .RuleFor(x => x.TokenId, Guid.Empty);

--- a/tests/Api.IntegrationTests/Helpers/App/RequestHelpers.cs
+++ b/tests/Api.IntegrationTests/Helpers/App/RequestHelpers.cs
@@ -9,7 +9,7 @@ public static class RequestHelpers
     public static Faker<SendMagicLinkRequest> GetMagicLinkRequestRules() => new Faker<SendMagicLinkRequest>()
         .RuleFor(x => x.UserId, () => Guid.NewGuid().ToString())
         .RuleFor(x => x.EmailAddress, faker => faker.Person.Email)
-        .RuleFor(x => x.UrlTemplate, faker => $"{faker.Internet.Url()}?token=__TOKEN__");
+        .RuleFor(x => x.UrlTemplate, faker => $"{faker.Internet.Url()}?token={SendMagicLinkRequest.TokenTemplate}");
 
     public static Faker<RegisterToken> GetRegisterTokenGeneratorRules() => new Faker<RegisterToken>()
         .RuleFor(x => x.UserId, Guid.NewGuid().ToString())


### PR DESCRIPTION
Characters such as `<>`, `{}`, and `[]` are frequently escaped by frameworks. Switching from `<token>` to `$TOKEN` for the token template will hopefully help keep this feature painless.