### PR TITLE
Fix migration script for production

### DIFF
--- a/src/Service/Migrations/Mssql/20240213130303_MagicLinkEmailQuota.cs
+++ b/src/Service/Migrations/Mssql/20240213130303_MagicLinkEmailQuota.cs
@@ -48,6 +48,9 @@ public partial class MagicLinkEmailQuota : Migration
             name: "IX_DispatchedEmails_Tenant",
             table: "DispatchedEmails",
             column: "Tenant");
+
+        migrationBuilder.Sql("UPDATE AppFeatures SET MagicLinkEmailMonthlyQuota = 100 WHERE MaxUsers = 10000;");
+        migrationBuilder.Sql("UPDATE AppFeatures SET MagicLinkEmailMonthlyQuota = 1000 WHERE MaxUsers IS NULL");
     }
 
     /// <inheritdoc />

--- a/src/Service/Migrations/Sqlite/20240213130331_MagicLinkEmailQuota.cs
+++ b/src/Service/Migrations/Sqlite/20240213130331_MagicLinkEmailQuota.cs
@@ -48,6 +48,9 @@ public partial class MagicLinkEmailQuota : Migration
             name: "IX_DispatchedEmails_Tenant",
             table: "DispatchedEmails",
             column: "Tenant");
+
+        migrationBuilder.Sql("UPDATE AppFeatures SET MagicLinkEmailMonthlyQuota = 100 WHERE MaxUsers = 10000;");
+        migrationBuilder.Sql("UPDATE AppFeatures SET MagicLinkEmailMonthlyQuota = 1000 WHERE MaxUsers IS NULL");
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
The initialization for the default values was left out in the last SQL Server and Sqlite migration. We can safely assume 10k MaxUsers means the `Trial` plan while all others are `Pro` or `Enterprise`.