### PR TITLE
.NET 8.0.2 `IDE0005` `dotnet format` issue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,8 +20,9 @@ dotnet_diagnostic.CA2253.severity = warning
 dotnet_diagnostic.CA2254.severity = warning
 # CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = warning
-# IDE0005: Using directive is unnecessary.
-dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0005: Using directive is unnecessary. Disable temporarily due to a bug in .NET 8.0.2.
+dotnet_diagnostic.IDE0005.severity = silent
 
 #### Core EditorConfig Options ####
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,7 +21,7 @@ dotnet_diagnostic.CA2254.severity = warning
 # CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = warning
 
-# IDE0005: Using directive is unnecessary. Disable temporarily due to a bug in .NET 8.0.2.
+# IDE0005: Using directive is unnecessary. Disable temporarily due to a bug introduced with the release of .NET 8.0.2.
 dotnet_diagnostic.IDE0005.severity = silent
 
 #### Core EditorConfig Options ####

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.101",
-    "rollForward": "latestMinor"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
- Bitwarden is also using `latestFeature` for an automatic rollover.
- If `latestMinor` is kept, we should disable `dotnet_diagnostic.IDE0005.severity`.

We could also consider looking into Matt Bischop's proposal to use a different solution: https://github.com/bitwarden/template/pull/14/files#diff-942a301e84bfe0b5304682d3ace46bcea39fd95bc4f6a600f64f1f2575fdf53f

Still working with Microsoft on resolving this.

Related:

- https://github.com/dotnet/roslyn/issues/72015
- https://github.com/dotnet/roslyn/issues/72160
- https://github.com/bitwarden/passwordless-server/actions/runs/7989471492/job/21816103177