### PR TITLE
Remove nuget-minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,11 +12,6 @@
       "groupName": "npm minor",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "groupName": "nuget minor",
-      "matchManagers": ["nuget"],
-      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
   "ignoreDeps": ["Datadog.Trace"]


### PR DESCRIPTION
Removing the `nuget-minor` grouping from the renovate config as it compiles too many different packages together and not everyone is diligently following semantic versioning.