### PR TITLE
Show Magic Link Setting

### DIFF
--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml
@@ -78,20 +78,17 @@
             Enable Manually Generated Verification Tokens
         </label>
         <br>
-        @if (Environment.IsDevelopment())
-        {
-            <h2>Magic Links</h2>
-            <p class="mt-3">
-                Magic Links provide a secure and user-friendly way to authenticate users in applications. While onboarding new
-                users into your application or in the event of account recovery, a Magic Link can be sent via email to gain access
-                to the system. This removes the friction of verifying users and resetting passkeys, enhancing the user experience.
-            </p>
-            <label asp-for="IsMagicLinksEnabled">
-                <input class="mr-1 my-4" type="checkbox" asp-for="IsMagicLinksEnabled"/>
-                Enable Magic Links
-            </label>
-            <br>
-        }
+        <h2>Magic Links</h2>
+        <p class="mt-3">
+            Magic Links provide a secure and user-friendly way to authenticate users in applications. While onboarding new
+            users into your application or in the event of account recovery, a Magic Link can be sent via email to gain access
+            to the system. This removes the friction of verifying users and resetting passkeys, enhancing the user experience.
+        </p>
+        <label asp-for="IsMagicLinksEnabled">
+            <input class="mr-1 my-4" type="checkbox" asp-for="IsMagicLinksEnabled"/>
+            Enable Magic Links
+        </label>
+        <br>
         <button id="btn-save-settings" class="btn-primary" type="submit">Save</button>
     </form>
 </div>


### PR DESCRIPTION
Now that the Magic Links endpoint is enabled, we should allow devs to turn it off and on via settings for their application.

Screenshots:
- Before
![image](https://github.com/bitwarden/passwordless-server/assets/7258973/1c668e96-66d0-4d52-91b7-5aefee6f699e)

- After
![image](https://github.com/bitwarden/passwordless-server/assets/7258973/50956ff2-17d1-4d21-a1df-47ab20e6b795)


Testing:
- Made sure both MGAT and Magic links settings worked when toggling on and off the features.