### PR TITLE
Upgrade Passwordless.AspNetCore to 2.0.0-beta6

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
-    <PackageReference Include="Passwordless.AspNetCore" Version="2.0.0-beta5" />
+    <PackageReference Include="Passwordless.AspNetCore" Version="2.0.0-beta6" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />

--- a/src/AdminConsole/EventLog/DTOs/AuditLogResponses.cs
+++ b/src/AdminConsole/EventLog/DTOs/AuditLogResponses.cs
@@ -1,7 +1,0 @@
-namespace Passwordless.AdminConsole.EventLog.DTOs;
-
-public record OrganizationEventLogResponse(int OrganizationId, IEnumerable<EventLogEvent> Events);
-
-public record ApplicationEventLogResponse(string TenantId, IEnumerable<EventLogEvent> Events, int TotalEventCount);
-
-public record EventLogEvent(DateTime PerformedAt, string EventType, string Message, string Severity, string PerformedBy, string Subject, string ApiKeyId);

--- a/src/AdminConsole/EventLog/DTOs/EventLogResponses.cs
+++ b/src/AdminConsole/EventLog/DTOs/EventLogResponses.cs
@@ -1,0 +1,24 @@
+using Passwordless.Models;
+
+namespace Passwordless.AdminConsole.EventLog.DTOs;
+
+public record OrganizationEventLogResponse(int OrganizationId, IEnumerable<EventLogEvent> Events);
+
+public record ApplicationEventLogResponse(string TenantId, IEnumerable<EventLogEvent> Events, int TotalEventCount);
+
+public record EventLogEvent(DateTime PerformedAt, string EventType, string Message, string Severity, string PerformedBy, string Subject, string ApiKeyId);
+
+public static class EventLogConversions
+{
+    public static ApplicationEventLogResponse ToDto(this GetEventLogResponse eventLogResponse) =>
+        new(eventLogResponse.TenantId, eventLogResponse.Events.Select(ToDto), eventLogResponse.TotalEventCount);
+
+    public static EventLogEvent ToDto(this ApplicationEvent applicationEvent) =>
+        new(applicationEvent.PerformedAt,
+            applicationEvent.EventType,
+            applicationEvent.Message,
+            applicationEvent.Severity,
+            string.Empty,
+            applicationEvent.Subject,
+            applicationEvent.ApiKeyId);
+}

--- a/src/AdminConsole/Pages/App/Credentials/List.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Credentials/List.cshtml.cs
@@ -26,7 +26,7 @@ public class ListModel : PageModel
 
     public async Task<IActionResult> OnPost(string token)
     {
-        var res = await _api.VerifyTokenAsync(token);
+        var res = await _api.VerifyAuthenticationTokenAsync(token);
         return new JsonResult(res);
     }
 

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml.cs
@@ -36,7 +36,7 @@ public class UserModel : PageModel
 
     public async Task<IActionResult> OnPost(string token)
     {
-        var res = await _passwordlessClient.VerifyTokenAsync(token);
+        var res = await _passwordlessClient.VerifyAuthenticationTokenAsync(token);
         return new JsonResult(res);
     }
 

--- a/src/AdminConsole/Pages/App/Playground/Client.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Playground/Client.cshtml.cs
@@ -21,7 +21,7 @@ public class ClientModel : PageModel
 
     public async Task<IActionResult> OnPost(string token)
     {
-        var res = await _passwordlessClient.VerifyTokenAsync(token);
+        var res = await _passwordlessClient.VerifyAuthenticationTokenAsync(token);
         return new JsonResult(res);
     }
 }

--- a/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml.cs
@@ -44,7 +44,7 @@ public class NewAccountModel : PageModel
 
     public async Task<IActionResult> OnPost(string token)
     {
-        var res = await _passwordlessClient.VerifyTokenAsync(token);
+        var res = await _passwordlessClient.VerifyAuthenticationTokenAsync(token);
         return new JsonResult(res);
     }
 

--- a/src/AdminConsole/Pages/Shared/CredentialsModel.cs
+++ b/src/AdminConsole/Pages/Shared/CredentialsModel.cs
@@ -30,7 +30,7 @@ public sealed class CredentialsModel
                     x.CreatedAt,
                     x.AaGuid,
                     x.LastUsedAt,
-                    x.RPID,
+                    x.RpId,
                     x.Origin,
                     x.Device,
                     x.Nickname,

--- a/src/AdminConsole/Services/EventLogService.cs
+++ b/src/AdminConsole/Services/EventLogService.cs
@@ -1,5 +1,6 @@
 using Passwordless.AdminConsole.EventLog.DTOs;
 using Passwordless.AdminConsole.EventLog.Loggers;
+using Passwordless.Models;
 
 namespace Passwordless.AdminConsole.Services;
 
@@ -29,6 +30,10 @@ public class EventLogService : IEventLogService
     public async Task<int> GetEventLogCount(int organizationId) =>
         await _storage.GetOrganizationEventCount(organizationId);
 
-    public async Task<ApplicationEventLogResponse> GetEventLogs(int pageNumber, int pageSize) =>
-        await _scopedPasswordlessClient.GetApplicationEventLog(pageNumber, pageSize);
+    public async Task<ApplicationEventLogResponse> GetEventLogs(int pageNumber, int pageSize)
+    {
+        var response = await _scopedPasswordlessClient.GetEventLogAsync(new GetEventLogRequest(pageNumber, pageSize));
+
+        return response.ToDto();
+    }
 }

--- a/src/AdminConsole/Services/ScopedPasswordlessClient.cs
+++ b/src/AdminConsole/Services/ScopedPasswordlessClient.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Options;
-using Passwordless.AdminConsole.EventLog.DTOs;
 using Passwordless.AdminConsole.Middleware;
 using Passwordless.AdminConsole.Services.PasswordlessManagement;
 using Passwordless.Common.Models.Apps;
@@ -11,7 +10,6 @@ namespace Passwordless.AdminConsole.Services;
 
 public interface IScopedPasswordlessClient : IPasswordlessClient
 {
-    Task<ApplicationEventLogResponse> GetApplicationEventLog(int pageNumber, int pageSize);
     Task<IEnumerable<PeriodicCredentialReportResponse>> GetPeriodicCredentialReportsAsync(PeriodicCredentialReportRequest request);
     Task<IEnumerable<PeriodicActiveUserReportResponse>> GetPeriodicActiveUserReportsAsync(PeriodicActiveUserReportRequest request);
 
@@ -58,14 +56,6 @@ public class ScopedPasswordlessClient : PasswordlessClient, IScopedPasswordlessC
         // can be dropped when call below is moved to the SDK.
         _client.DefaultRequestHeaders.Remove("ApiSecret");
         _client.DefaultRequestHeaders.Add("ApiSecret", context.ApiSecret);
-    }
-
-    public async Task<ApplicationEventLogResponse> GetApplicationEventLog(int pageNumber, int pageSize)
-    {
-        var response = await _client.GetAsync($"events?pageNumber={pageNumber}&numberOfResults={pageSize}");
-        response.EnsureSuccessStatusCode();
-
-        return (await response.Content.ReadFromJsonAsync<ApplicationEventLogResponse>())!;
     }
 
     public async Task<IEnumerable<PeriodicCredentialReportResponse>> GetPeriodicCredentialReportsAsync(PeriodicCredentialReportRequest request)


### PR DESCRIPTION
- Upgraded to beta6
- Updated references to `VerifyTokenAsync` with `VerifyAuthenticationTokenAsync`
- Switched Application Event Log to use SDK