### PR TITLE
Fix app deletion

### DIFF
--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -210,7 +210,8 @@ public class SharedManagementService : ISharedManagementService
 
     public async Task<AppDeletionResult> DeleteApplicationAsync(string appId)
     {
-        var accountInformation = await _tenantStorage.GetAccountInformation();
+        var storage = tenantFactory.Create(appId);
+        var accountInformation = await storage.GetAccountInformation();
 
         if (accountInformation == null)
         {
@@ -233,7 +234,8 @@ public class SharedManagementService : ISharedManagementService
 
     public async Task<AppDeletionResult> MarkDeleteApplicationAsync(string appId, string deletedBy, string baseUrl)
     {
-        var accountInformation = await _tenantStorage.GetAccountInformation();
+        var storage = tenantFactory.Create(appId);
+        var accountInformation = await storage.GetAccountInformation();
         if (accountInformation == null)
         {
             throw new ApiException("app_not_found", "App was not found.", 400);

--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -222,7 +222,7 @@ public class SharedManagementService : ISharedManagementService
             throw new ApiException("app_not_pending_deletion", "App was not scheduled for deletion.", 400);
         }
 
-        await _tenantStorage.DeleteAccount();
+        await storage.DeleteAccount();
 
         return new AppDeletionResult(
             $"The app '{accountInformation.AcountName}' was deleted.",
@@ -249,12 +249,12 @@ public class SharedManagementService : ISharedManagementService
 
         if (!canDeleteImmediately)
         {
-            canDeleteImmediately = !(await _tenantStorage.HasUsersAsync());
+            canDeleteImmediately = !(await storage.HasUsersAsync());
         }
 
         if (canDeleteImmediately)
         {
-            await _tenantStorage.DeleteAccount();
+            await storage.DeleteAccount();
             return new AppDeletionResult(
                 $"The app '{accountInformation.AcountName}' was deleted.",
                 true,
@@ -263,10 +263,10 @@ public class SharedManagementService : ISharedManagementService
         }
 
         // Lock/Freeze all API keys that have been issued.
-        await _tenantStorage.LockAllApiKeys(true);
+        await storage.LockAllApiKeys(true);
 
         var deleteAt = _systemClock.UtcNow.AddMonths(1).UtcDateTime;
-        await _tenantStorage.SetAppDeletionDate(deleteAt);
+        await storage.SetAppDeletionDate(deleteAt);
 
         return new AppDeletionResult(
             $"The app '{accountInformation.AcountName}' will be deleted at '{deleteAt}'.",

--- a/src/Service/Storage/Ef/EfTenantStorage.cs
+++ b/src/Service/Storage/Ef/EfTenantStorage.cs
@@ -15,7 +15,6 @@ public class EfTenantStorage(
 {
     public string Tenant => tenantProvider.Tenant;
 
-
     public Task<ApiKeyDesc> GetApiKeyAsync(string apiKey)
     {
         var appId = ApiKeyUtils.GetAppId(apiKey);


### PR DESCRIPTION
Issue:
Currently, there is an issue with deleting the app due to some refactoring and scoping issues of the tenant storage.  This will fix the storage issues for now.  It uses the tenant factory to get an instance instead of the injected one. Later, we'll come back and finish swapping out the tenant factory with the tenant storage injected through DI.

Validation:
- I am now able to delete an application.