### PR TITLE
Sanitize application name and description

### DIFF
--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
@@ -33,8 +33,7 @@ public class CreateApplicationModel : PageModel
         IApplicationService applicationService,
         IDataService dataService,
         IPasswordlessManagementClient managementClient,
-        IOptionsSnapshot<BillingOptions> billingOptions,
-        ISharedBillingService billingService)
+        IOptionsSnapshot<BillingOptions> billingOptions, ISharedBillingService billingService)
     {
         _dataService = dataService;
         _applicationService = applicationService;

--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
@@ -166,13 +166,13 @@ public class CreateApplicationModel : PageModel
 
     public class CreateApplicationForm
     {
-        [Required, MaxLength(60)]
+        [Required, MaxLength(60), MinLength(3), RegularExpression("^[a-zA-Z]{1}[a-zA-Z0-9 ]{2,59}$")]
         public string Name { get; set; }
 
-        [Required, MaxLength(62)]
+        [Required, MaxLength(62), MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")]
         public string Id { get; set; }
 
-        [Required, MaxLength(120)]
+        [Required, MaxLength(120), MinLength(3), RegularExpression("^[a-zA-Z]{1}[a-zA-Z0-9 ]{2,119}$")]
         public string Description { get; set; }
 
         [Required]

--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
@@ -166,7 +166,7 @@ public class CreateApplicationModel : PageModel
 
     public class CreateApplicationForm
     {
-        [Required, MaxLength(60), MinLength(3), RegularExpression("^[a-zA-Z]{1}[a-zA-Z0-9 ]{2,59}$")]
+        [Required, MaxLength(60), MinLength(3), RegularExpression("^[a-zA-Z0-9 -.?!;:]{3,60}$")]
         public string Name { get; set; }
 
         [Required, MaxLength(62), MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")]

--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml.cs
@@ -12,6 +12,7 @@ using Passwordless.AdminConsole.RoutingHelpers;
 using Passwordless.AdminConsole.Services;
 using Passwordless.AdminConsole.Services.PasswordlessManagement;
 using Passwordless.Common.Models.Apps;
+using Passwordless.Common.Serialization;
 using Application = Passwordless.AdminConsole.Models.Application;
 
 namespace Passwordless.AdminConsole.Pages.Organization;
@@ -32,7 +33,8 @@ public class CreateApplicationModel : PageModel
         IApplicationService applicationService,
         IDataService dataService,
         IPasswordlessManagementClient managementClient,
-        IOptionsSnapshot<BillingOptions> billingOptions, ISharedBillingService billingService)
+        IOptionsSnapshot<BillingOptions> billingOptions,
+        ISharedBillingService billingService)
     {
         _dataService = dataService;
         _applicationService = applicationService;
@@ -166,14 +168,38 @@ public class CreateApplicationModel : PageModel
 
     public class CreateApplicationForm
     {
-        [Required, MaxLength(60), MinLength(3), RegularExpression("^[a-zA-Z0-9 -.?!;:]{3,60}$")]
-        public string Name { get; set; }
+        private string _name;
+
+        [Required, MaxLength(60), MinLength(3)]
+        public string Name
+        {
+            get
+            {
+                return _name;
+            }
+            set
+            {
+                _name = HtmlSanitizer.Sanitize(value);
+            }
+        }
 
         [Required, MaxLength(62), MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")]
         public string Id { get; set; }
 
-        [Required, MaxLength(120), MinLength(3), RegularExpression("^[a-zA-Z]{1}[a-zA-Z0-9 ]{2,119}$")]
-        public string Description { get; set; }
+        private string _description;
+
+        [Required, MaxLength(120), MinLength(3)]
+        public string Description
+        {
+            get
+            {
+                return _description;
+            }
+            set
+            {
+                _description = HtmlSanitizer.Sanitize(value);
+            }
+        }
 
         [Required]
         public string Plan { get; set; }

--- a/src/Api/Endpoints/Apps.cs
+++ b/src/Api/Endpoints/Apps.cs
@@ -21,14 +21,13 @@ public static class AppsEndpoints
             .WithParameterValidation();
 
         app.MapPost("/admin/apps/{appId}/create", async (
-                [FromRoute, MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")] string appId,
-                [FromBody] CreateAppDto payload,
-                ISharedManagementService service,
-                IEventLogger eventLogger) =>
+                [AsParameters] CreateApplicationRequest request,
+                [FromServices] ISharedManagementService service,
+                [FromServices] IEventLogger eventLogger) =>
             {
-                var result = await service.GenerateAccount(appId, payload);
+                var result = await service.GenerateAccount(request.AppId, request.Payload);
 
-                eventLogger.LogApplicationCreatedEvent(payload.AdminEmail);
+                eventLogger.LogApplicationCreatedEvent(request.Payload.AdminEmail);
 
                 return Ok(result);
             })

--- a/src/Api/Endpoints/Apps.cs
+++ b/src/Api/Endpoints/Apps.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Helpers;
@@ -20,7 +21,7 @@ public static class AppsEndpoints
             .WithParameterValidation();
 
         app.MapPost("/admin/apps/{appId}/create", async (
-                [FromRoute] string appId,
+                [FromRoute, MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")] string appId,
                 [FromBody] CreateAppDto payload,
                 ISharedManagementService service,
                 IEventLogger eventLogger) =>
@@ -31,6 +32,7 @@ public static class AppsEndpoints
 
                 return Ok(result);
             })
+            .WithParameterValidation()
             .RequireManagementKey()
             .RequireCors("default");
 

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="8.0.843" />
     <PackageReference Include="MailKit" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
     <PackageReference Include="Postmark" Version="4.7.10" />

--- a/src/Common/Models/Apps/CreateAppDto.cs
+++ b/src/Common/Models/Apps/CreateAppDto.cs
@@ -5,7 +5,9 @@ public record CreateAppDto
     public string AdminEmail { get; set; } = "";
 
     public bool EventLoggingIsEnabled { get; set; } = false;
+
     public int EventLoggingRetentionPeriod { get; set; } = 365;
+
     public int MagicLinkEmailMonthlyQuota { get; set; }
 
     /// <summary>

--- a/src/Common/Models/Apps/CreateApplicationRequest.cs
+++ b/src/Common/Models/Apps/CreateApplicationRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Passwordless.Common.Models.Apps;
+
+public class CreateApplicationRequest
+{
+    [FromRoute, MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")]
+    public required string AppId { get; set; }
+
+    [FromBody]
+    public required CreateAppDto Payload { get; set; }
+}

--- a/src/Common/Models/Apps/CreateApplicationRequest.cs
+++ b/src/Common/Models/Apps/CreateApplicationRequest.cs
@@ -5,7 +5,8 @@ namespace Passwordless.Common.Models.Apps;
 
 public class CreateApplicationRequest
 {
-    [FromRoute, MinLength(3), RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$")]
+    [FromRoute, MinLength(3)]
+    [RegularExpression("^[a-z]{1}[a-z0-9]{2,61}$", ErrorMessage = "'AppId' must be between 3 and 62 characters, contain only lowercase letters and numbers, and start with a lowercase letter.")]
     public required string AppId { get; set; }
 
     [FromBody]

--- a/src/Common/Serialization/HtmlSanitizer.cs
+++ b/src/Common/Serialization/HtmlSanitizer.cs
@@ -1,0 +1,11 @@
+namespace Passwordless.Common.Serialization;
+
+public static class HtmlSanitizer
+{
+    private static readonly Ganss.Xss.HtmlSanitizer _htmlSanitizer = new();
+
+    public static string Sanitize(string input)
+    {
+        return _htmlSanitizer.Sanitize(input);
+    }
+}

--- a/src/Common/Serialization/HtmlSanitizer.cs
+++ b/src/Common/Serialization/HtmlSanitizer.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Ganss.Xss;
 
 namespace Passwordless.Common.Serialization;
@@ -14,6 +15,8 @@ public static class HtmlSanitizer
 
     public static string Sanitize(string input)
     {
-        return _htmlSanitizer.Sanitize(input);
+        var temp = new StringBuilder(_htmlSanitizer.Sanitize(input));
+        temp.Replace("https://", string.Empty).Replace("http://", string.Empty);
+        return temp.ToString();
     }
 }

--- a/src/Common/Serialization/HtmlSanitizer.cs
+++ b/src/Common/Serialization/HtmlSanitizer.cs
@@ -1,8 +1,13 @@
+using Ganss.Xss;
+
 namespace Passwordless.Common.Serialization;
 
 public static class HtmlSanitizer
 {
-    private static readonly Ganss.Xss.HtmlSanitizer _htmlSanitizer = new();
+    private static readonly Ganss.Xss.HtmlSanitizer _htmlSanitizer = new(new HtmlSanitizerOptions
+    {
+        AllowedTags = new HashSet<string>(0)
+    });
 
     public static string Sanitize(string input)
     {

--- a/src/Common/Serialization/HtmlSanitizer.cs
+++ b/src/Common/Serialization/HtmlSanitizer.cs
@@ -7,7 +7,10 @@ public static class HtmlSanitizer
     private static readonly Ganss.Xss.HtmlSanitizer _htmlSanitizer = new(new HtmlSanitizerOptions
     {
         AllowedTags = new HashSet<string>(0)
-    });
+    })
+    {
+        KeepChildNodes = true
+    };
 
     public static string Sanitize(string input)
     {

--- a/tests/AdminConsole.Tests/AdminConsole.Tests.csproj
+++ b/tests/AdminConsole.Tests/AdminConsole.Tests.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="bunit" Version="1.26.64" />
+    <PackageReference Include="bunit" Version="1.25.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2"/>

--- a/tests/Api.IntegrationTests/Endpoints/App/AppTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/App/AppTests.cs
@@ -38,7 +38,7 @@ public class AppTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFi
 
         var content = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         content.Should().NotBeNull();
-        content!.Title.Should().Be("accountName needs to be alphanumeric and start with a letter");
+        content!.Title.Should().Be("One or more validation errors occurred.");
     }
 
     [Fact]

--- a/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
+++ b/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Passwordless.Common.Serialization;
 
@@ -10,6 +11,21 @@ public class HtmlSanitizerTests
     {
         // Arrange
         var input = "<script>alert('hello');</script>";
+
+        // Act
+        var result = HtmlSanitizer.Sanitize(input);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("<p>hello</p>")]
+    [InlineData("<a href='https://example.com'>hello</a>")]
+    [InlineData("<strong>hello</strong>")]
+    public void Sanitize_WhenGivenHtmlWithAllowedTags_ShouldReturnSanitizedHtml(string input)
+    {
+        // Arrange
 
         // Act
         var result = HtmlSanitizer.Sanitize(input);

--- a/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
+++ b/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
@@ -13,24 +13,25 @@ public class HtmlSanitizerTests
         var input = "<script>alert('hello');</script>";
 
         // Act
-        var result = HtmlSanitizer.Sanitize(input);
+        var actual = HtmlSanitizer.Sanitize(input);
 
         // Assert
-        result.Should().BeEmpty();
+        Assert.Equal("alert('hello');", actual);
     }
 
     [Theory]
     [InlineData("<p>hello</p>")]
     [InlineData("<a href='https://example.com'>hello</a>")]
     [InlineData("<strong>hello</strong>")]
+    [InlineData("<a><a>hello</a></a>")]
     public void Sanitize_WhenGivenHtmlWithAllowedTags_ShouldReturnSanitizedHtml(string input)
     {
         // Arrange
 
         // Act
-        var result = HtmlSanitizer.Sanitize(input);
+        var actual = HtmlSanitizer.Sanitize(input);
 
         // Assert
-        result.Should().BeEmpty();
+        Assert.Equal("hello", actual);
     }
 }

--- a/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
+++ b/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-using FluentAssertions;
 using Passwordless.Common.Serialization;
 
 namespace Passwordless.Common.Tests.Serialization;
@@ -25,6 +23,20 @@ public class HtmlSanitizerTests
     [InlineData("<strong>hello</strong>")]
     [InlineData("<a><a>hello</a></a>")]
     public void Sanitize_WhenGivenHtmlWithAllowedTags_ShouldReturnSanitizedHtml(string input)
+    {
+        // Arrange
+
+        // Act
+        var actual = HtmlSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal("hello", actual);
+    }
+
+    [Theory]
+    [InlineData("https://hello")]
+    [InlineData("http://hello")]
+    public void Sanitize_WhenGivenStringContainingScheme_ShouldReturnSanitizedHtml(string input)
     {
         // Arrange
 

--- a/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
+++ b/tests/Common.Tests/Serialization/HtmlSanitizerTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using Passwordless.Common.Serialization;
+
+namespace Passwordless.Common.Tests.Serialization;
+
+public class HtmlSanitizerTests
+{
+    [Fact]
+    public void Sanitize_WhenGivenHtml_ShouldReturnSanitizedHtml()
+    {
+        // Arrange
+        var input = "<script>alert('hello');</script>";
+
+        // Act
+        var result = HtmlSanitizer.Sanitize(input);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
- We have no validation on the `appId` when an application is being created. For the validation to work on the route parameter, I needed to wrap it inside another object.
- Removes 'https://', 'http://', and HTML tags from application name and description.