### PR TITLE
Dynamic matrix cases for the `deploy` job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,8 @@ jobs:
 
   # Dispatches a separate deployment workflow in a private repository
   deploy:
+    if: ${{ github.event_name != 'pull_request' }}
+  
     needs:
       - version
       - format
@@ -194,17 +196,26 @@ jobs:
           - devtest
           - qa
           - prod
+        is-release:
+          - ${{ github.event_name == 'release' }}
+        # We can't have a dynamic job condition based on matrix parameters
+        # so we use this matrix hack as a workaround for that.
+        # The goal is to include qa/prod environments only when triggered
+        # by a release event.
+        exclude:
+          - environment: qa
+            is-release: false
+          - environment: prod
+            is-release: false
+
+    # Specify the name of the job manually due to the matrix hack below
+    name: deploy (${{ matrix.environment }})
 
     runs-on: ubuntu-latest
     permissions: {} # no permissions required
 
     steps:
       - name: Dispatch deployment
-        # Ideally this condition should be on the job itself, but the job's condition
-        # cannot reference matrix parameters.
-        if: ${{ (matrix.environment == 'devtest' && github.event_name != 'pull_request') ||
-                (matrix.environment == 'qa' && github.event_name == 'release') ||
-                (matrix.environment == 'prod' && github.event_name == 'release') }}
         env:
           GITHUB_TOKEN: ${{ secrets.DEPLOYMENT_GITHUB_TOKEN }}
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,20 +196,11 @@ jobs:
           - devtest
           - qa
           - prod
-        is-release:
-          - ${{ github.event_name == 'release' }}
-        # We can't have a dynamic job condition based on matrix parameters
-        # so we use this matrix hack as a workaround for that.
-        # The goal is to include qa/prod environments only when triggered
-        # by a release event.
         exclude:
-          - environment: qa
-            is-release: false
-          - environment: prod
-            is-release: false
-
-    # Specify the name of the job manually due to the matrix hack above
-    name: deploy (${{ matrix.environment }})
+          # Exclude QA and PROD if not triggered by a release event
+          # https://stackoverflow.com/questions/65384420/how-do-i-make-a-github-action-matrix-element-conditional
+          - environment: ${{ github.event_name != 'release' && 'qa' || '_' }}
+          - environment: ${{ github.event_name != 'release' && 'prod' || '_' }}
 
     runs-on: ubuntu-latest
     permissions: {} # no permissions required

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,7 @@ jobs:
           - environment: prod
             is-release: false
 
-    # Specify the name of the job manually due to the matrix hack below
+    # Specify the name of the job manually due to the matrix hack above
     name: deploy (${{ matrix.environment }})
 
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,8 +199,8 @@ jobs:
         exclude:
           # Exclude QA and PROD if not triggered by a release event
           # https://stackoverflow.com/questions/65384420/how-do-i-make-a-github-action-matrix-element-conditional
-          - environment: ${{ github.event_name != 'release' && 'qa' || '_' }}
-          - environment: ${{ github.event_name != 'release' && 'prod' || '_' }}
+          - environment: ${{ github.event_name != 'release' && 'qa' }}
+          - environment: ${{ github.event_name != 'release' && 'prod' }}
 
     runs-on: ubuntu-latest
     permissions: {} # no permissions required


### PR DESCRIPTION
Currently, the job runs on all environments and just selectively skips the deployment step if the trigger event is not applicable (e.g. `push` for `prod` instead of `release`). This is fine, but it results in all instances of the `deploy` job marked as having completed, even if they didn't actually do anything.

As a workaround, I've changed the matrix to include an `is-release` parameter. It will be applied to all matrix cases like shown below.

- Workflow triggered by a release event:
  - Generated matrix:
    - `environment: devtest` / `is-release: true`
	- `environment: qa` / `is-release: true`
	- `environment: prod` / `is-release: true`
  - Exclusion on `is-release: false` does not apply since all cases are `true`
  - Final matrix is the same as the generated matrix
  - Deployment will happen to all environments 

- Workflow triggered by a non-release event (e.g. normal commit to `main`):
  - Generated matrix:
    - `environment: devtest` / `is-release: false`
	- `environment: qa` / `is-release: false`
	- `environment: prod` / `is-release: false`
  - Exclusion on `is-release: false` applies to the last two cases
  - Final matrix:
    - `environment: devtest` / `is-release: false`
  - Deployment only happens to `devtest`