### PR TITLE
Switch from `DateTimeOffest` to `DateTime` in EF models

### DIFF
--- a/src/Service/Migrations/Mssql/20240228181428_DateTimeOffsetToDateTime.Designer.cs
+++ b/src/Service/Migrations/Mssql/20240228181428_DateTimeOffsetToDateTime.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Passwordless.Service.Storage.Ef;
 
@@ -11,9 +12,11 @@ using Passwordless.Service.Storage.Ef;
 namespace Passwordless.Service.Migrations.Mssql
 {
     [DbContext(typeof(DbGlobalMsSqlContext))]
-    partial class MsSqlContextModelSnapshot : ModelSnapshot
+    [Migration("20240228181428_DateTimeOffsetToDateTime")]
+    partial class DateTimeOffsetToDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Service/Migrations/Mssql/20240228181428_DateTimeOffsetToDateTime.cs
+++ b/src/Service/Migrations/Mssql/20240228181428_DateTimeOffsetToDateTime.cs
@@ -3,33 +3,32 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Passwordless.Service.Migrations.Mssql
+namespace Passwordless.Service.Migrations.Mssql;
+
+/// <inheritdoc />
+public partial class DateTimeOffsetToDateTime : Migration
 {
     /// <inheritdoc />
-    public partial class DateTimeOffsetToDateTime : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<DateTime>(
-                name: "CreatedAt",
-                table: "DispatchedEmails",
-                type: "datetime2",
-                nullable: false,
-                oldClrType: typeof(DateTimeOffset),
-                oldType: "datetimeoffset");
-        }
+        migrationBuilder.AlterColumn<DateTime>(
+            name: "CreatedAt",
+            table: "DispatchedEmails",
+            type: "datetime2",
+            nullable: false,
+            oldClrType: typeof(DateTimeOffset),
+            oldType: "datetimeoffset");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<DateTimeOffset>(
-                name: "CreatedAt",
-                table: "DispatchedEmails",
-                type: "datetimeoffset",
-                nullable: false,
-                oldClrType: typeof(DateTime),
-                oldType: "datetime2");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "DispatchedEmails",
+            type: "datetimeoffset",
+            nullable: false,
+            oldClrType: typeof(DateTime),
+            oldType: "datetime2");
     }
 }

--- a/src/Service/Migrations/Mssql/20240228181428_DateTimeOffsetToDateTime.cs
+++ b/src/Service/Migrations/Mssql/20240228181428_DateTimeOffsetToDateTime.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Passwordless.Service.Migrations.Mssql
+{
+    /// <inheritdoc />
+    public partial class DateTimeOffsetToDateTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "DispatchedEmails",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "datetimeoffset");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "DispatchedEmails",
+                type: "datetimeoffset",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+    }
+}

--- a/src/Service/Migrations/Sqlite/20240228181418_DateTimeOffsetToDateTime.Designer.cs
+++ b/src/Service/Migrations/Sqlite/20240228181418_DateTimeOffsetToDateTime.Designer.cs
@@ -2,59 +2,57 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Passwordless.Service.Storage.Ef;
 
 #nullable disable
 
-namespace Passwordless.Service.Migrations.Mssql
+namespace Passwordless.Service.Migrations.Sqlite
 {
-    [DbContext(typeof(DbGlobalMsSqlContext))]
-    partial class MsSqlContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(DbGlobalSqliteContext))]
+    [Migration("20240228181418_DateTimeOffsetToDateTime")]
+    partial class DateTimeOffsetToDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.1")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.1");
 
             modelBuilder.Entity("Passwordless.Service.EventLog.Models.ApplicationEvent", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ApiKeyId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("EventType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Message")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("PerformedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PerformedBy")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Severity")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Subject")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -66,21 +64,21 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.AccountMetaInformation", b =>
                 {
                     b.Property<string>("AcountName")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AdminEmailsSerialized")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("DeleteAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Tenant")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("AcountName");
 
@@ -90,17 +88,17 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.AliasPointer", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Plaintext")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Tenant", "Alias");
 
@@ -110,30 +108,30 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.ApiKeyDesc", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ApiKey")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsLocked")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("LastLockedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("LastUnlockedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Scopes")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Tenant", "Id");
 
@@ -143,35 +141,35 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.AppFeature", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("AllowAttestation")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("DeveloperLoggingEndsAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("EventLoggingIsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("EventLoggingRetentionPeriod")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsGenerateSignInTokenEndpointEnabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsMagicLinksEnabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<int>("MagicLinkEmailMonthlyQuota")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long?>("MaxUsers")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Tenant");
 
@@ -181,16 +179,16 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.Authenticator", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("AaGuid")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsAllowed")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Tenant", "AaGuid");
 
@@ -201,26 +199,26 @@ namespace Passwordless.Service.Migrations.Mssql
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LinkTemplate")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Tenant")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -234,70 +232,70 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.EFStoredCredential", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte[]>("DescriptorId")
-                        .HasColumnType("varbinary(900)");
+                        .HasColumnType("BLOB");
 
                     b.Property<Guid?>("AaGuid")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AttestationFmt")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool?>("BackupState")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Country")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DescriptorTransports")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("DescriptorType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Device")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool?>("IsBackupEligible")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool?>("IsDiscoverable")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("LastUsedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Nickname")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Origin")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte[]>("PublicKey")
                         .IsRequired()
-                        .HasColumnType("varbinary(max)");
+                        .HasColumnType("BLOB");
 
                     b.Property<string>("RPID")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<long>("SignatureCounter")
-                        .HasColumnType("bigint");
+                    b.Property<uint>("SignatureCounter")
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte[]>("UserHandle")
                         .IsRequired()
-                        .HasColumnType("varbinary(max)");
+                        .HasColumnType("BLOB");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Tenant", "DescriptorId");
 
@@ -307,19 +305,19 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.PeriodicActiveUserReport", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateOnly>("CreatedAt")
-                        .HasColumnType("date");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("DailyActiveUsersCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TotalUsersCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("WeeklyActiveUsersCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Tenant", "CreatedAt");
 
@@ -329,16 +327,16 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.PeriodicCredentialReport", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateOnly>("CreatedAt")
-                        .HasColumnType("date");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("CredentialsCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("UsersCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Tenant", "CreatedAt");
 
@@ -348,17 +346,17 @@ namespace Passwordless.Service.Migrations.Mssql
             modelBuilder.Entity("Passwordless.Service.Models.TokenKey", b =>
                 {
                     b.Property<string>("Tenant")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("KeyId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("KeyMaterial")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Tenant", "KeyId");
 

--- a/src/Service/Migrations/Sqlite/20240228181418_DateTimeOffsetToDateTime.cs
+++ b/src/Service/Migrations/Sqlite/20240228181418_DateTimeOffsetToDateTime.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Passwordless.Service.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    public partial class DateTimeOffsetToDateTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/Service/Migrations/Sqlite/20240228181418_DateTimeOffsetToDateTime.cs
+++ b/src/Service/Migrations/Sqlite/20240228181418_DateTimeOffsetToDateTime.cs
@@ -2,21 +2,20 @@
 
 #nullable disable
 
-namespace Passwordless.Service.Migrations.Sqlite
+namespace Passwordless.Service.Migrations.Sqlite;
+
+/// <inheritdoc />
+public partial class DateTimeOffsetToDateTime : Migration
 {
     /// <inheritdoc />
-    public partial class DateTimeOffsetToDateTime : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
 
-        }
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
 
-        }
     }
 }

--- a/src/Service/Migrations/Sqlite/SqliteContextModelSnapshot.cs
+++ b/src/Service/Migrations/Sqlite/SqliteContextModelSnapshot.cs
@@ -198,7 +198,7 @@ namespace Passwordless.Service.Migrations.Sqlite
                         .ValueGeneratedOnAdd()
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("CreatedAt")
+                    b.Property<DateTime>("CreatedAt")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("EmailAddress")

--- a/src/Service/Models/DispatchedEmail.cs
+++ b/src/Service/Models/DispatchedEmail.cs
@@ -4,7 +4,7 @@ public class DispatchedEmail : PerTenant
 {
     public required Guid Id { get; set; }
 
-    public required DateTimeOffset CreatedAt { get; set; }
+    public required DateTime CreatedAt { get; set; }
 
     public required string UserId { get; set; }
 

--- a/src/Service/Storage/Ef/DbGlobalSqliteContext.cs
+++ b/src/Service/Storage/Ef/DbGlobalSqliteContext.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Passwordless.Service.Storage.Ef;
 
@@ -8,34 +7,5 @@ public class DbGlobalSqliteContext : DbGlobalContext
     public DbGlobalSqliteContext(DbContextOptions<DbGlobalSqliteContext> options)
         : base(options)
     {
-    }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-
-        // SQLite does not have proper support for DateTimeOffset via Entity Framework Core, see the limitations
-        // here: https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations
-        // To work around this, when the Sqlite database provider is used, all model properties of type DateTimeOffset
-        // use the DateTimeOffsetToBinaryConverter
-        // Based on: https://github.com/aspnet/EntityFrameworkCore/issues/10784#issuecomment-415769754
-        // This only supports millisecond precision, but should be sufficient for most use cases.
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
-        {
-            var properties = entityType.ClrType
-                .GetProperties()
-                .Where(p =>
-                    p.PropertyType == typeof(DateTimeOffset) ||
-                    p.PropertyType == typeof(DateTimeOffset?)
-                );
-
-            foreach (var property in properties)
-            {
-                modelBuilder
-                    .Entity(entityType.Name)
-                    .Property(property.Name)
-                    .HasConversion(new DateTimeOffsetToBinaryConverter());
-            }
-        }
     }
 }

--- a/src/Service/Storage/Ef/DbGlobalSqliteContext.cs
+++ b/src/Service/Storage/Ef/DbGlobalSqliteContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Passwordless.Service.Storage.Ef;
 
@@ -7,5 +8,34 @@ public class DbGlobalSqliteContext : DbGlobalContext
     public DbGlobalSqliteContext(DbContextOptions<DbGlobalSqliteContext> options)
         : base(options)
     {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // SQLite does not have proper support for DateTimeOffset via Entity Framework Core, see the limitations
+        // here: https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations
+        // To work around this, when the Sqlite database provider is used, all model properties of type DateTimeOffset
+        // use the DateTimeOffsetToBinaryConverter
+        // Based on: https://github.com/aspnet/EntityFrameworkCore/issues/10784#issuecomment-415769754
+        // This only supports millisecond precision, but should be sufficient for most use cases.
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var properties = entityType.ClrType
+                .GetProperties()
+                .Where(p =>
+                    p.PropertyType == typeof(DateTimeOffset) ||
+                    p.PropertyType == typeof(DateTimeOffset?)
+                );
+
+            foreach (var property in properties)
+            {
+                modelBuilder
+                    .Entity(entityType.Name)
+                    .Property(property.Name)
+                    .HasConversion(new DateTimeOffsetToBinaryConverter());
+            }
+        }
     }
 }

--- a/src/Service/Storage/Ef/EfTenantStorage.cs
+++ b/src/Service/Storage/Ef/EfTenantStorage.cs
@@ -328,7 +328,7 @@ public class EfTenantStorage(
         {
             Tenant = Tenant,
             Id = Guid.NewGuid(),
-            CreatedAt = timeProvider.GetUtcNow(),
+            CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
             UserId = userId,
             EmailAddress = emailAddress,
             LinkTemplate = linkTemplate


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request.
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

<!-- Title format if there is a Jira Ticket: PAS-XXX | short pr description -->

### Ticket

N/A

### Description

As it turns out, EF Core provider for SQLite does not support `DateTimeOffset` comparisons, so queries like the one below fail:

```csharp
var from = timeProvider.GetUtcNow() - window;
return await db.DispatchedEmails
    // CreatedAt is of type DateTimeOffset
    .Where(x => x.CreatedAt >= from)
    .ToArrayAsync();
```

Interestingly, even though SQLite does not have any native support for dates (no `datetime` or similar column type), EF Core is able to handle the above query just fine when using regular `DateTime` on the CLR type. Why it doesn't work with `DateTimeOffest` is a mystery.

While you can provide a custom `ValueConverter` and `ValueComparer` inside `OnModelCreating`, this doesn't ultimately help with `>`/`<` comparisons that's used in the query above.

https://docs.microsoft.com/en-us/ef/core/providers/sqlite/limitations#query-limitations

### Shape

This changes the affected property from `DateTimeOffset` to `DateTime`. Migrations included will change the backing column type the MSSQL from `datetimeoffset` to `datetime2`.

### Screenshots

N/A

### Checklist

I did the following to ensure that my changes were tested thoroughly:
- [X] I ran the existing tests against both MSSQL and SQLite and both worked

I did the following to ensure that my changes did not introduce new security vulnerabilities:
N/A