### PR TITLE
PAS-379 | Event logging wording allow list & block list

### DIFF
--- a/src/Api/Endpoints/Authenticators.cs
+++ b/src/Api/Endpoints/Authenticators.cs
@@ -53,7 +53,7 @@ public static class AuthenticatorsEndpoints
         }
 
         await service.AddAuthenticatorsAsync(request);
-        eventLogger.LogAuthenticatorsWhitelistedEvent();
+        eventLogger.LogAuthenticatorsAllowlistedEvent();
         return NoContent();
     }
 

--- a/src/Common/EventLog/Enums/EventType.cs
+++ b/src/Common/EventLog/Enums/EventType.cs
@@ -23,7 +23,7 @@ public enum EventType
     ApiManagementAppCreated = 1202,
     ApiManagementAppFrozen = 1203,
     ApiManagementAppUnfrozen = 1204,
-    ApiAuthenticatorsWhitelisted = 1300,
+    ApiAuthenticatorsAllowlisted = 1300,
     ApiAuthenticatorsBlacklisted = 1301,
     ApiAuthenticatorsDelisted = 1302,
     AdminOrganizationCreated = 7000,

--- a/src/Service/EventLog/Loggers/IEventLogger.cs
+++ b/src/Service/EventLog/Loggers/IEventLogger.cs
@@ -352,14 +352,14 @@ public static class EventLoggerExtensions
             ApiKeyId = string.Empty
         });
 
-    public static void LogAuthenticatorsWhitelistedEvent(this IEventLogger logger) =>
+    public static void LogAuthenticatorsAllowlistedEvent(this IEventLogger logger) =>
         logger.LogEvent(context => new EventDto
         {
             PerformedAt = context.PerformedAt,
-            Message = "Authenticators whitelisted.",
+            Message = "Authenticators added to allowlist.",
             PerformedBy = "Unknown User",
             TenantId = context.TenantId,
-            EventType = EventType.ApiAuthenticatorsWhitelisted,
+            EventType = EventType.ApiAuthenticatorsAllowlisted,
             Severity = Severity.Informational,
             Subject = context.TenantId,
             ApiKeyId = context.AbbreviatedKey
@@ -369,7 +369,7 @@ public static class EventLoggerExtensions
         logger.LogEvent(context => new EventDto
         {
             PerformedAt = context.PerformedAt,
-            Message = "Authenticators removed from whitelist or blacklist.",
+            Message = "Authenticators removed from allowlist or blocklist.",
             PerformedBy = "Unknown User",
             TenantId = context.TenantId,
             EventType = EventType.ApiAuthenticatorsDelisted,


### PR DESCRIPTION
### Ticket

- Closes [PAS-379](https://bitwarden.atlassian.net/browse/PAS-379)

### Description

- Changes the wording of whitelist and blacklist to allowlist and blocklist respectively.

### Shape

n/a

### Screenshots

n/a

### Checklist

I did the following to ensure that my changes were tested thoroughly:
- [ ] __
- [ ] __

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] __
- [ ] __


[PAS-379]: https://bitwarden.atlassian.net/browse/PAS-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ