### PR TITLE
PAS-330 | Charts: Filenames for export

### DIFF
--- a/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalCredentialsCountChart.razor
+++ b/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalCredentialsCountChart.razor
@@ -1,12 +1,13 @@
 @using Passwordless.Common.Models.Reporting
 @using Passwordless.AdminConsole.Components.Shared.ApexCharts.Models
 
-<ApexChart Id="total-credentials-count-chart" Options="_options" YAxisFormatting="LabelsFormattingTypes.Integer" />
+<ApexChart Id="@Id" Options="_options" YAxisFormatting="LabelsFormattingTypes.Integer" />
 
 @code {
     [Parameter] public required IEnumerable<PeriodicCredentialReportResponse> Data { get; set; }
 
     private const int MinDataPoints = 3;
+    private const string Id = "total-credentials-count-chart";
     
     private ApexChartOptions<DateTime, int>? _options;
 
@@ -21,6 +22,10 @@
         {
             Chart = new()
             {
+                Toolbar = new Toolbar
+                {
+                    Export = new Export()
+                },
                 Type = ChartTypes.Line
             },
             Series = new List<Series<int>>
@@ -41,5 +46,6 @@
                 Categories = Data.Select(x => x.CreatedAt.ToDateTime(new TimeOnly(0, 0)))
             }
         };
+        _options.Chart.Toolbar.Export.SetFilename(Id);
     } 
 }

--- a/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalUsersCountChart.razor
+++ b/src/AdminConsole/Components/Pages/App/ReportingComponents/TotalUsersCountChart.razor
@@ -1,13 +1,14 @@
 @using Passwordless.Common.Models.Reporting
 @using Passwordless.AdminConsole.Components.Shared.ApexCharts.Models
 
-<ApexChart Id="total-users-count-chart" Options="_options" YAxisFormatting="LabelsFormattingTypes.Integer" />
+<ApexChart Id="@Id" Options="_options" YAxisFormatting="LabelsFormattingTypes.Integer" />
 
 @code {
     [Parameter]
     public required IEnumerable<PeriodicCredentialReportResponse> Data { get; set; }
 
     private const int MinDataPoints = 3;
+    private const string Id = "total-users-count-chart";
 
     private ApexChartOptions<DateTime, int>? _options;
     
@@ -22,6 +23,10 @@
         {
             Chart = new Chart
             {
+                Toolbar = new Toolbar
+                {
+                    Export = new Export()
+                },
                 Type = ChartTypes.Line
             },
             Series = new List<Series<int>>
@@ -42,5 +47,6 @@
                 Categories = Data.Select(x => x.CreatedAt.ToDateTime(new TimeOnly(0, 0)))
             }
         };
+        _options.Chart.Toolbar.Export.SetFilename(Id);
     }
 }

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/Chart.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/Chart.cs
@@ -5,4 +5,6 @@ public class Chart
     public ChartTypes Type { get; set; }
 
     public string? Height { get; set; }
+
+    public Toolbar? Toolbar { get; set; }
 }

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/Export.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/Export.cs
@@ -1,0 +1,33 @@
+namespace Passwordless.AdminConsole.Components.Shared.ApexCharts.Models;
+
+public class Export
+{
+    public ExportCsv Csv { get; } = new();
+
+    public ExportSvg Svg { get; } = new();
+
+    public ExportPng Png { get; } = new();
+
+
+    /// <summary>
+    /// Sets the file name for all export types.
+    /// </summary>
+    /// <param name="filename">File name without file extension.</param>
+    public void SetFilename(string filename)
+    {
+        Csv.Filename = filename;
+        Svg.Filename = filename;
+        Png.Filename = filename;
+    }
+}
+
+public abstract class BaseExport
+{
+    public string? Filename { get; set; }
+}
+
+public class ExportCsv : BaseExport;
+
+public class ExportSvg : BaseExport;
+
+public class ExportPng : BaseExport;

--- a/src/AdminConsole/Components/Shared/ApexCharts/Models/Toolbar.cs
+++ b/src/AdminConsole/Components/Shared/ApexCharts/Models/Toolbar.cs
@@ -1,0 +1,6 @@
+namespace Passwordless.AdminConsole.Components.Shared.ApexCharts.Models;
+
+public class Toolbar
+{
+    public Export? Export { get; set; }
+}


### PR DESCRIPTION
### Ticket

- Closes [PAS-330](https://bitwarden.atlassian.net/browse/PAS-330)

### Description

Presently, when files are being exported, the filenames are essentially 8 random alphanumeric characters followed by their file extension: `fsdhsdfi.csv`, `fsdhsdfi.png`, `fsdhsdfi.svg`. This pull request sets the id of the chart, eg `total-users-count-chart` as the file name. Resulting in the following file names:

- `total-users-count-chart.csv`,
- `total-users-count-chart.png`,
- `total-users-count-chart.svg`

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] Download SVG
- [ ] Download PNG
- [ ] Download CSV

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] n/a


[PAS-330]: https://bitwarden.atlassian.net/browse/PAS-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ