### PR TITLE
PAS-262 | Display icons for authenticators

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
@@ -41,7 +41,7 @@
 
             <hr/>
             <EditForm id="manage-form-id" class="flex-col space-y-4" Model="Data" FormName="manage-form" OnSubmit="OnAuthenticatorModified">
-                <Table ColumnHeaders="@(new []{ "Allowed", "Description", "AaGuid", "Attestation Types", "Certification Level"})" EmptyMessage="No authenticators found using applied filters.">
+                <Table ColumnHeaders="@(new []{ "Allowed", string.Empty, "Description", "AaGuid", "Attestation Types", "Certification Level"})" EmptyMessage="No authenticators found using applied filters.">
                     @if (Data != null)
                     {
                         @foreach (var item in Data)
@@ -49,6 +49,9 @@
                             <tr>
                                 <td class="relative px-7 sm:w-12 sm:px-6">
                                     <input name="ManageForm.Selected" type="checkbox" checked="@item.IsSelected" value="@item.AaGuid"/>
+                                </td>
+                                <td class="block">
+                                    <img class="w-8" src="@item.Icon" alt="@item.AaGuid" />
                                 </td>
                                 <td class="text-sm font-medium text-gray-900">@item.Name</td>
                                 <td class="whitespace-nowrap">@item.AaGuid</td>
@@ -197,13 +200,14 @@
         Guid AaGuid,
         string Name,
         IEnumerable<string> CertificationStatuses,
-        IEnumerable<string> AttestationTypes)
+        IEnumerable<string> AttestationTypes,
+        string Icon)
     {
         public bool IsSelected { get; set; }
 
         public static ListViewModel FromDto(EntryResponse dto)
         {
-            return new ListViewModel(dto.AaGuid, dto.Name, dto.CertificationStatuses, dto.AttestationTypes);
+            return new ListViewModel(dto.AaGuid, dto.Name, dto.CertificationStatuses, dto.AttestationTypes, dto.Icon);
         }
     }
 }

--- a/src/Common/Models/MDS/EntryResponse.cs
+++ b/src/Common/Models/MDS/EntryResponse.cs
@@ -4,8 +4,10 @@ namespace Passwordless.Common.Models.MDS;
 /// <param name="Name">Authenticator name</param>
 /// <param name="CertificationStatuses">Certification statuses</param>
 /// <param name="AttestationTypes">Supported attestation types</param>
+/// <param name="Icon">Icon</param>
 public record EntryResponse(
     Guid AaGuid,
     string Name,
     IEnumerable<string> CertificationStatuses,
-    IEnumerable<string> AttestationTypes);
+    IEnumerable<string> AttestationTypes,
+    string Icon);

--- a/src/Service/MDS/MetaDataService.cs
+++ b/src/Service/MDS/MetaDataService.cs
@@ -46,7 +46,8 @@ public sealed class MetaDataService : DistributedCacheMetadataService, IMetaData
                     x.AaGuid!.Value,
                     x.MetadataStatement.Description,
                     x.StatusReports.Select(statusReport => statusReport.Status.ToString()),
-                    x.MetadataStatement.AttestationTypes)
+                    x.MetadataStatement.AttestationTypes,
+                    x.MetadataStatement.Icon)
             );
 
         if (request.AttestationTypes != null && request.AttestationTypes.Any())

--- a/tests/AdminConsole.Tests/Components/Pages/App/Settings/AuthenticatorsTests.cs
+++ b/tests/AdminConsole.Tests/Components/Pages/App/Settings/AuthenticatorsTests.cs
@@ -35,9 +35,9 @@ public class AuthenticatorsTests : TestContext
         // Arrange
         var mds = new List<EntryResponse>
         {
-            new (Guid.Parse("cb69481e-8ff7-4039-93ec-0a2729a154b1"), "Bitwarden Authenticator", new[] { "FIDO_CERTIFIED", "FIDO_CERTIFIED_L1" }, new[] { "basic_full" }),
-            new (Guid.Parse("cb69481e-8ff7-4039-93ec-0a2729a154a9"), "Authenticator #2", new[] { "FIDO_CERTIFIED", "FIDO_CERTIFIED_L1" }, new[] { "basic_full" }),
-            new (Guid.Parse("cb69481e-8ff7-4039-93ec-0a2729a154a8"), "Authenticator #1", new[] { "FIDO_CERTIFIED_L2" }, new[] { "basic_full" })
+            new (Guid.Parse("cb69481e-8ff7-4039-93ec-0a2729a154b1"), "Bitwarden Authenticator", new[] { "FIDO_CERTIFIED", "FIDO_CERTIFIED_L1" }, new[] { "basic_full" }, "icon1"),
+            new (Guid.Parse("cb69481e-8ff7-4039-93ec-0a2729a154a9"), "Authenticator #2", new[] { "FIDO_CERTIFIED", "FIDO_CERTIFIED_L1" }, new[] { "basic_full" }, "icon2"),
+            new (Guid.Parse("cb69481e-8ff7-4039-93ec-0a2729a154a8"), "Authenticator #1", new[] { "FIDO_CERTIFIED_L2" }, new[] { "basic_full" }, "icon3")
         };
         var features = _fixture
             .Build<ApplicationFeatureContext>()


### PR DESCRIPTION
### Ticket

- Closes [PAS-262](https://bitwarden.atlassian.net/browse/PAS-262)

### Description

We were previously not displaying authenticator icons. Now we do. I did not want to take up too much space. It does seem like all authenticators have icons in the metadata statement.

### Shape

n/a

### Screenshots

![image](https://github.com/bitwarden/passwordless-server/assets/1045327/382f1b13-415c-413b-82c1-35713bc6dfc1)

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] Open the page that allows you to modify the allowlist of the authenticators.

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] n/a

The MDS should be a trusted source of of data given we verify the signature of the blob we download.