### PR TITLE
PAS-382 | Refactor import maps

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -63,7 +63,7 @@
     <Copy SourceFiles="node_modules\es-module-shims\dist\es-module-shims.js" DestinationFolder="wwwroot\lib\es-module-shims\" />
     
     <!-- Vue.js -->
-    <Copy SourceFiles="node_modules\vue\dist\vue.esm-browser.js" DestinationFolder="wwwroot\lib\vue\" />
-    <Copy SourceFiles="node_modules\vue\dist\vue.esm-browser.prod.js" DestinationFolder="wwwroot\lib\vue\" />
+    <Copy Condition="'$(Configuration)' == 'Debug'" SourceFiles="node_modules\vue\dist\vue.esm-browser.js" DestinationFiles="wwwroot\lib\vue\vue.mjs" />
+    <Copy Condition="'$(Configuration)' == 'Release'" SourceFiles="node_modules\vue\dist\vue.esm-browser.prod.js" DestinationFiles="wwwroot\lib\vue\vue.mjs" />
   </Target>
 </Project>

--- a/src/AdminConsole/Helpers/RazorPageHtmlExtensions.cs
+++ b/src/AdminConsole/Helpers/RazorPageHtmlExtensions.cs
@@ -11,17 +11,14 @@ namespace Passwordless.AdminConsole.Helpers;
 
 public static class RazorPageHtmlExtensions
 {
-    public static IHtmlContent ImportMap(this IHtmlHelper html, Dictionary<string, (string Dev, string Prod)> importMaps, IFileVersionProvider fileVersionProvider, string? nonce = null)
+    public static IHtmlContent ImportMap(this IHtmlHelper html, Dictionary<string, string> importMaps, IFileVersionProvider fileVersionProvider, string? nonce = null)
     {
         var map = new Dictionary<string, object>();
         var imports = new Dictionary<string, object> { ["imports"] = map };
 
-        // check if we are in development environment
-        var isDev = html.ViewContext.HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment();
-
         foreach (var importMap in importMaps)
         {
-            map[importMap.Key] = isDev ? importMap.Value.Dev : importMap.Value.Prod;
+            map[importMap.Key] = importMap.Value;
             map[importMap.Key] = fileVersionProvider.AddFileVersionToPath(html.ViewContext.HttpContext.Request.PathBase, map[importMap.Key].ToString());
         }
 
@@ -68,5 +65,4 @@ public static class RazorPageHtmlExtensions
         }
         return contentBuilder;
     }
-
 }

--- a/src/AdminConsole/Pages/Shared/_Layout.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Layout.cshtml
@@ -5,6 +5,8 @@
 @using Passwordless.AdminConsole.Identity
 @inject SignInManager<ConsoleAdmin> signinManager
 @inject IFileVersionProvider FileVersionProvider
+@inject IHttpContextAccessor HttpContextAccessor
+
 @{
     var signedIn = signinManager.IsSignedIn(User);
 }
@@ -72,7 +74,7 @@
     
 
 <script async src="@Url.Content("~/lib/es-module-shims/es-module-shims.js")" asp-append-version="true"></script>
-@Html.ImportMap(new Dictionary<string, (string Dev, string Prod)> { ["vue"] = ("/lib/vue/vue.esm-browser.js", "/lib/vue/vue.esm-browser.prod.js") }, FileVersionProvider);
+@Html.ImportMap(new Dictionary<string, string> { ["vue"] = "/lib/vue/vue.mjs" }, FileVersionProvider)
 <script type="text/javascript" src="~/js/core.js" asp-append-version="true"></script>
 <script type="module" src="@Url.Content("~/js/elements/local-time.mjs")" asp-append-version="true"></script>
 <script type="module" src="/js/confirm-form.mjs" asp-append-version="true"></script>

--- a/src/AdminConsole/Pages/Shared/_Layout.cshtml
+++ b/src/AdminConsole/Pages/Shared/_Layout.cshtml
@@ -23,8 +23,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
+    @Html.ImportMap(new Dictionary<string, string> { ["vue"] = "/lib/vue/vue.mjs" }, FileVersionProvider)
     @await RenderSectionAsync("Head", false)
     @Html.RenderPartialSectionScripts()
+    <script async src="@Url.Content("~/lib/es-module-shims/es-module-shims.js")" asp-append-version="true"></script>
 </head>
 
 <body class="h-full bg-gray-50">
@@ -72,9 +74,6 @@
     }
 </div>
     
-
-<script async src="@Url.Content("~/lib/es-module-shims/es-module-shims.js")" asp-append-version="true"></script>
-@Html.ImportMap(new Dictionary<string, string> { ["vue"] = "/lib/vue/vue.mjs" }, FileVersionProvider)
 <script type="text/javascript" src="~/js/core.js" asp-append-version="true"></script>
 <script type="module" src="@Url.Content("~/js/elements/local-time.mjs")" asp-append-version="true"></script>
 <script type="module" src="/js/confirm-form.mjs" asp-append-version="true"></script>


### PR DESCRIPTION
### Ticket

- Related [PAS-382](https://bitwarden.atlassian.net/browse/PAS-382)

### Description

We can save some resources every request by moving the correct vue.js dependency into the static web assets folder.

It also fixes a bug where Vue.js wasn't properly being imported with the importmaps `es-shim-module`.

Error 1:
`An import map is added after module script load was triggered.`

Error 2:
`(3) profile:1 Uncaught TypeError: Failed to resolve module specifier "vue". Relative references must start with either "/", "./", or "../".`

### Shape

We can save some resources every request by moving the correct vue.js dependency into the static web assets folder. When building in debug mode, it makes sense to use the debuggable library. Otherwise use the minified production one.

We could consider getting rid of import maps to improve security further.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] __
- [ ] __

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] __
- [ ] __


[PAS-382]: https://bitwarden.atlassian.net/browse/PAS-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ