### PR TITLE
PAS-384 | Fix delete passkey bug once and for all

### DIFF
--- a/src/AdminConsole/Components/Shared/Credentials.razor
+++ b/src/AdminConsole/Components/Shared/Credentials.razor
@@ -4,7 +4,6 @@
 
 @inject IAuthenticatorDataProvider AuthenticatorDataProvider
 @inject IHttpContextAccessor HttpContextAccessor
-@inject IScopedPasswordlessClient PasswordlessClient
 @inject NavigationManager NavigationManager
 
 @if (Items != null)

--- a/src/AdminConsole/Components/Shared/Credentials.razor.cs
+++ b/src/AdminConsole/Components/Shared/Credentials.razor.cs
@@ -10,10 +10,6 @@ public partial class Credentials : ComponentBase
 {
     public const string RemoveCredentialFormName = "remove-credential-form";
 
-    /// <summary>
-    /// The list of credentials.
-    /// </summary>
-    [Parameter]
     public required IReadOnlyCollection<Credential> Items { get; set; }
 
     public IReadOnlyCollection<CredentialModel> GetItems()
@@ -46,11 +42,18 @@ public partial class Credentials : ComponentBase
     [Parameter]
     public bool HideDetails { get; set; }
 
+    [Parameter]
+    public required IPasswordlessClient PasswordlessClient { get; set; }
+
+    [Parameter]
+    public required string UserId { get; set; }
+
     [SupplyParameterFromForm(FormName = RemoveCredentialFormName)]
     public DeleteCredentialFormModel DeleteCredentialForm { get; set; } = new();
 
     protected override async Task OnInitializedAsync()
     {
+        Items = await PasswordlessClient.ListCredentialsAsync(UserId);
         // If we've posted a form, we need to add backwards compatibility for Razor Pages. Bind it to the model, and trigger the form submission handler.
         if (HttpContextAccessor.IsRazorPages() && HttpContextAccessor.HttpContext!.Request.HasFormContentType)
         {

--- a/src/AdminConsole/Pages/Account/Profile.cshtml
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Antiforgery
 @model Passwordless.AdminConsole.Pages.Account.Profile
 @inject IAntiforgery Antiforgery
+@inject IPasswordlessClient PasswordlessClient
 
 @{
     ViewData["Title"] = "Profile Settings";
@@ -10,7 +11,7 @@
 
 <div class="panel">
     <h2>Passkeys</h2>   
-    <component type="typeof(Credentials)" render-mode="Static" param-Items="@(Model.Credentials)" param-HideDetails="@(false)" />
+    <component type="typeof(Credentials)" render-mode="Static" param-HideDetails="@false" param-PasswordlessClient="@PasswordlessClient" param-UserId="@Model.UserId" />
     <partial name="Shared/_PasswordlessClientJs"/>
     <partial name="Shared/_AddPasskeys"/>
 </div>

--- a/src/AdminConsole/Pages/Account/Profile.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml.cs
@@ -1,9 +1,9 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Passwordless.AdminConsole.Helpers;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class Profile : PageModel
 {
-    public string UserId => HttpContext.User.Claims.Single(c => c.Type == ClaimTypes.NameIdentifier).Value;
+    public string UserId => HttpContext.User.GetId();
 }

--- a/src/AdminConsole/Pages/Account/Profile.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml.cs
@@ -1,39 +1,9 @@
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Passwordless.AdminConsole.Identity;
-using Passwordless.AdminConsole.Services.AuthenticatorData;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class Profile : PageModel
 {
-    private readonly IPasswordlessClient _client;
-    private readonly UserManager<ConsoleAdmin> _userManager;
-
-    public Profile(
-        IPasswordlessClient client,
-        UserManager<ConsoleAdmin> userManager,
-        IAuthenticatorDataProvider authenticatorDataProvider)
-    {
-        _client = client;
-        _userManager = userManager;
-    }
-
-    public IReadOnlyCollection<Credential> Credentials { get; set; }
-
-    public async Task<IActionResult> OnPostRemoveCredential(string credentialId)
-    {
-        await _client.DeleteCredentialAsync(credentialId);
-        return RedirectToPage();
-    }
-
-    public async Task OnGet()
-    {
-        var userId = _userManager.GetUserId(HttpContext.User);
-        if (userId != null)
-        {
-            Credentials = await _client.ListCredentialsAsync(userId);
-        }
-    }
+    public string UserId => HttpContext.User.Claims.Single(c => c.Type == ClaimTypes.NameIdentifier).Value;
 }

--- a/src/AdminConsole/Pages/Account/UserOnboarding.cshtml
+++ b/src/AdminConsole/Pages/Account/UserOnboarding.cshtml
@@ -1,6 +1,8 @@
 @page
 @model Passwordless.AdminConsole.Pages.Account.UserOnboarding
 
+@inject IPasswordlessClient PasswordlessClient
+
 @{
     ViewBag.Title = "Let's get you set up";
 }
@@ -9,7 +11,7 @@
     <p class="v-cloak" v-if="supportsPasskeys">We noticed your device supports passkeys, let's add one to secure your account.</p>
     <p class="v-cloak" v-if="!supportsPasskeys.value && supportsSecurityKeys.value">We noticed your device supports security keys, so if you have a yubikey you can use it to secure your account.</p>
     
-    <component type="typeof(Credentials)" render-mode="Static" param-Items="@(Model.Credentials)" param-HideDetails="@(true)" />
+    <component type="typeof(Credentials)" render-mode="Static" param-HideDetails="@(true)" param-PasswordlessClient="@(PasswordlessClient)" param-UserId="@Model.UserId" />
     <partial name="Shared/_PasswordlessClientJs" />
     <partial name="Shared/_AddPasskeys" />
 </panel>

--- a/src/AdminConsole/Pages/Account/UserOnboarding.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/UserOnboarding.cshtml.cs
@@ -1,9 +1,9 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Passwordless.AdminConsole.Helpers;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class UserOnboarding : PageModel
 {
-    public string UserId => HttpContext.User.Claims.Single(c => c.Type == ClaimTypes.NameIdentifier).Value;
+    public string UserId => HttpContext.User.GetId();
 }

--- a/src/AdminConsole/Pages/Account/UserOnboarding.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/UserOnboarding.cshtml.cs
@@ -1,25 +1,9 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Passwordless.AdminConsole.Services.AuthenticatorData;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class UserOnboarding : PageModel
 {
-    private readonly IPasswordlessClient _passwordlessClient;
-
-    public UserOnboarding(
-        IPasswordlessClient passwordlessClient,
-        IAuthenticatorDataProvider authenticatorDataProvider)
-    {
-        _passwordlessClient = passwordlessClient;
-    }
-
-    public IReadOnlyCollection<Credential> Credentials { get; set; }
-
-    public async Task OnGet()
-    {
-        Credentials = await _passwordlessClient.ListCredentialsAsync(HttpContext.User.Claims
-            .FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value);
-    }
+    public string UserId => HttpContext.User.Claims.Single(c => c.Type == ClaimTypes.NameIdentifier).Value;
 }

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml
@@ -8,7 +8,7 @@
 <div id="vue">
     <p>This pages summarizes the information for user <partial name="_Badge" model="@Model.UserId"/></p>
 
-    <component type="typeof(Credentials)" render-mode="Static" param-Items="@(Model.Credentials)" param-HideDetails="@(false)" />
+    <component type="typeof(Credentials)" render-mode="Static" param-HideDetails="@(false)" param-PasswordlessClient="@Model.PasswordlessClient" param-UserId="@(Model.UserId)"  />
     
     <div class="sm:flex sm:items-center mt-8 mb-4">
         <div class="sm:flex-auto">

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml.cs
@@ -7,10 +7,6 @@ namespace Passwordless.AdminConsole.Pages.App.Credentials;
 
 public class UserModel : PageModel
 {
-    private readonly ILogger<IndexModel> _logger;
-    private readonly IScopedPasswordlessClient _passwordlessClient;
-
-    public IReadOnlyCollection<Credential> Credentials { get; set; }
     public IReadOnlyCollection<AliasPointer> Aliases { get; set; }
 
     [BindProperty(SupportsGet = true)]
@@ -18,22 +14,15 @@ public class UserModel : PageModel
 
     public UserModel(
         IAuthenticatorDataProvider authenticatorDataProvider,
-        ILogger<IndexModel> logger,
         IScopedPasswordlessClient api)
     {
-        _logger = logger;
-        _passwordlessClient = api;
+        PasswordlessClient = api;
     }
+
+    public IScopedPasswordlessClient PasswordlessClient { get; }
 
     public async Task OnGet()
     {
-        Credentials = await _passwordlessClient.ListCredentialsAsync(UserId);
-        Aliases = await _passwordlessClient.ListAliasesAsync(UserId);
-    }
-
-    public async Task<IActionResult> OnPostRemoveCredential(string credentialId)
-    {
-        await _passwordlessClient.DeleteCredentialAsync(credentialId);
-        return RedirectToPage();
+        Aliases = await PasswordlessClient.ListAliasesAsync(UserId);
     }
 }

--- a/src/AdminConsole/Pages/App/Credentials/User.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Credentials/User.cshtml.cs
@@ -12,9 +12,7 @@ public class UserModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string UserId { get; set; }
 
-    public UserModel(
-        IAuthenticatorDataProvider authenticatorDataProvider,
-        IScopedPasswordlessClient api)
+    public UserModel(IScopedPasswordlessClient api)
     {
         PasswordlessClient = api;
     }


### PR DESCRIPTION
### Ticket

- Closes [PAS-384](https://bitwarden.atlassian.net/browse/PAS-384)

### Description

We were unable to delete passkeys on the profile page, because it was trying to use the `IScopedPasswordlessClient`. We're now injecting the `IPasswordlessClient` or its derivative `IScopedPasswordlessClient` using the `PasswordlessClient` parameter on the`Credentials.razor` component. A second parameter was then created to pass the `UserId`.

Similarly the user is passed from the claim, rather than using the expensive `UserManager<ConsoleAdmin>` calling the database with an additional trip. The credentials for a user in a given app for a customer are passed using a query parameter `userId` this behavior was not changed.

### Shape

See above.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] Test all 3 screens where credentials were present

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] Reduced security impact where user id can be obtained from the claim directly for a logged-in admin


[PAS-384]: https://bitwarden.atlassian.net/browse/PAS-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ