### PR TITLE
PAS-262 | Icon for authenticators without icon in MDS

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
@@ -53,7 +53,7 @@
                                 <td class="table-cell min-w-16 w-16">
                                     @if (string.IsNullOrEmpty(item.Icon))
                                     {
-                                        <Fido2AuthenticatorIcon class="fill-blue-400" />
+                                        <Fido2AuthenticatorIcon class="fill-blue-400 w-full" />
                                     }
                                     else
                                     {

--- a/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
@@ -211,7 +211,7 @@
         string Name,
         IEnumerable<string> CertificationStatuses,
         IEnumerable<string> AttestationTypes,
-        string Icon)
+        string? Icon)
     {
         public bool IsSelected { get; set; }
 

--- a/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
@@ -50,14 +50,14 @@
                                 <td class="relative px-7 sm:w-12 sm:px-6">
                                     <input name="ManageForm.Selected" type="checkbox" checked="@item.IsSelected" value="@item.AaGuid"/>
                                 </td>
-                                <td class="table-cell min-w-16 w-16">
+                                <td class="table-cell">
                                     @if (string.IsNullOrEmpty(item.Icon))
                                     {
-                                        <Fido2AuthenticatorIcon class="fill-blue-400 w-full" />
+                                        <Fido2AuthenticatorIcon class="fill-blue-400 w-16 max-h-16" />
                                     }
                                     else
                                     {
-                                        <img class="w-full" src="@item.Icon" alt="@item.AaGuid"/>
+                                        <img class="w-16" src="@item.Icon" alt="@item.AaGuid"/>
                                     }
                                 </td>
                                 <td class="text-sm font-medium text-gray-900">@item.Name</td>

--- a/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/ManageAuthenticators.razor
@@ -41,7 +41,7 @@
 
             <hr/>
             <EditForm id="manage-form-id" class="flex-col space-y-4" Model="Data" FormName="manage-form" OnSubmit="OnAuthenticatorModified">
-                <Table ColumnHeaders="@(new []{ "Allowed", string.Empty, "Description", "AaGuid", "Attestation Types", "Certification Level"})" EmptyMessage="No authenticators found using applied filters.">
+                <Table ColumnHeaders="@(new []{ "Allow", string.Empty, "Description", "AaGuid", "Attestation Types", "Certification Level"})" EmptyMessage="No authenticators found using applied filters.">
                     @if (Data != null)
                     {
                         @foreach (var item in Data)
@@ -50,11 +50,18 @@
                                 <td class="relative px-7 sm:w-12 sm:px-6">
                                     <input name="ManageForm.Selected" type="checkbox" checked="@item.IsSelected" value="@item.AaGuid"/>
                                 </td>
-                                <td class="block">
-                                    <img class="w-8" src="@item.Icon" alt="@item.AaGuid" />
+                                <td class="table-cell min-w-16 w-16">
+                                    @if (string.IsNullOrEmpty(item.Icon))
+                                    {
+                                        <Fido2AuthenticatorIcon class="fill-blue-400" />
+                                    }
+                                    else
+                                    {
+                                        <img class="w-full" src="@item.Icon" alt="@item.AaGuid"/>
+                                    }
                                 </td>
                                 <td class="text-sm font-medium text-gray-900">@item.Name</td>
-                                <td class="whitespace-nowrap">@item.AaGuid</td>
+                                <td class="whitespace-nowrap font-mono">@item.AaGuid</td>
                                 <td class="whitespace-nowrap">
                                     <ul>
                                         @foreach (var type in item.AttestationTypes)
@@ -110,16 +117,19 @@
 
 @code {
     private bool _isInitialized;
-    
-    [SupplyParameterFromForm(FormName = "filter-form")] public FilterViewModel FilterForm { get; set; } = new();
-    [SupplyParameterFromForm(FormName = "manage-form")] public ManageViewModel ManageForm { get; set; } = new();
-    
+
+    [SupplyParameterFromForm(FormName = "filter-form")]
+    public FilterViewModel FilterForm { get; set; } = new();
+
+    [SupplyParameterFromForm(FormName = "manage-form")]
+    public ManageViewModel ManageForm { get; set; } = new();
+
     public IEnumerable<string>? AttestationTypes { get; private set; }
     public IEnumerable<string>? CertificationLevels { get; private set; }
     public IReadOnlyCollection<ListViewModel>? Data { get; private set; }
-    
+
     private IReadOnlyCollection<BreadCrumb.BreadCrumbItem>? _breadCrumbs;
-    
+
     protected override async Task OnInitializedAsync()
     {
         _breadCrumbs = new List<BreadCrumb.BreadCrumbItem>
@@ -128,15 +138,15 @@
             new("Authenticators", $"app/{AppId}/settings/authenticators"),
             new("Allowlist", $"app/{AppId}/settings/authenticators/manage")
         };
-        
+
         if (!CurrentContext.Features.AllowAttestation)
         {
             NavigationManager.NavigateTo($"app/{AppId}/settings");
             return;
         }
-        
-        
-        
+
+
+
         AttestationTypes = await ManagementClient.GetAttestationTypesAsync();
         CertificationLevels = await ManagementClient.GetCertificationStatusesAsync();
 
@@ -144,7 +154,7 @@
 
         var configuredAuthenticatorsRequest = new ConfiguredAuthenticatorRequest(true);
         var allowedAuthenticators = await PasswordlessClient.GetConfiguredAuthenticatorsAsync(configuredAuthenticatorsRequest);
-        
+
         Data = data.Select(x =>
         {
             var viewModel = ListViewModel.FromDto(x);
@@ -179,7 +189,7 @@
         public string? AttestationType { get; set; }
 
         public string? CertificationStatus { get; set; }
-        
+
         public EntriesRequest ToDto()
         {
             return new EntriesRequest

--- a/src/AdminConsole/Components/Shared/Icons/Fido2AuthenticatorIcon.razor
+++ b/src/AdminConsole/Components/Shared/Icons/Fido2AuthenticatorIcon.razor
@@ -1,0 +1,10 @@
+<svg @attributes="@AdditionalAttributes" viewBox="0 0 176 176" width="176" height="176" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="0">
+    <path d="M 92.7 152.92 L 45.7 152.92 C 38.301 152.986 32.251 147.039 32.19 139.64 L 32.19 36.36 C 32.256 28.971 38.291 23.03 45.68 23.08 L 92.68 23.08 C 100.077 23.019 106.124 28.963 106.19 36.36 L 106.19 139.64 C 106.13 147.031 100.092 152.975 92.7 152.92 Z M 45.68 29.81 C 42 29.76 38.975 32.7 38.92 36.38 L 38.92 139.64 C 38.975 143.32 42 146.26 45.68 146.21 L 92.68 146.21 C 96.36 146.26 99.385 143.32 99.44 139.64 L 99.44 36.36 C 99.375 32.696 96.365 29.771 92.7 29.81 L 45.68 29.81 Z" style="transform-origin: 69.19px 88px;" transform="matrix(0, -1, 1, 0, -0.000003814697, 0)"  fill-rule="evenodd" />
+    <path d="M 174.42 105.74 L 133.56 105.74 C 131.705 105.74 130.2 104.235 130.2 102.38 L 130.2 70.26 L 136.92 70.26 L 136.92 99.01 L 171.07 99.01 L 171.07 70.26 L 177.78 70.26 L 177.78 102.38 C 177.78 104.235 176.276 105.74 174.42 105.74 Z" style="transform-origin: 153.99px 88px;" transform="matrix(0, -1, 1, 0, 0, 0)" fill-rule="evenodd" />
+    <text style="font-family: Arial, sans-serif; font-size: 31px; font-weight: 700; white-space: pre;" x="22.997" y="100.121">FIDO2</text>
+</svg>
+
+@code {
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/src/Common/Models/MDS/EntryResponse.cs
+++ b/src/Common/Models/MDS/EntryResponse.cs
@@ -10,4 +10,4 @@ public record EntryResponse(
     string Name,
     IEnumerable<string> CertificationStatuses,
     IEnumerable<string> AttestationTypes,
-    string Icon);
+    string? Icon);


### PR DESCRIPTION
### Ticket

- Closes [PAS-262](https://bitwarden.atlassian.net/browse/PAS-262)

### Description

- Some authenticators do not have an icon in the MDS. Render a basic icon.
- Format all aaguids so they have the same length to make it more presentable.

### Shape

n/a

### Screenshots

<img width="823" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/da6f8d65-1073-4d1b-8a9a-f8f5f3003a34">

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] __
- [ ] __

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] __
- [ ] __


[PAS-262]: https://bitwarden.atlassian.net/browse/PAS-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ