### PR TITLE
Use `ExecuteDeleteAsync` to delete an organization.

### DIFF
--- a/src/AdminConsole/Services/DataService.cs
+++ b/src/AdminConsole/Services/DataService.cs
@@ -78,9 +78,7 @@ public class DataService : IDataService
 
     public async Task<bool> DeleteOrganizationAsync()
     {
-        var rowsAffected = await _db.Organizations
-            .Where(x => x.Id == _orgId)
-            .ExecuteDeleteAsync();
+        var rowsAffected = await _db.Organizations.Where(x => x.Id == _orgId).ExecuteDeleteAsync();
         return rowsAffected > 0;
     }
 

--- a/src/AdminConsole/Services/DataService.cs
+++ b/src/AdminConsole/Services/DataService.cs
@@ -78,10 +78,9 @@ public class DataService : IDataService
 
     public async Task<bool> DeleteOrganizationAsync()
     {
-        var organization = await _db.Organizations.FirstOrDefaultAsync(x => x.Id == _orgId);
-        if (organization == null) return false;
-        _db.Organizations.Remove(organization);
-        var rowsAffected = await _db.SaveChangesAsync();
+        var rowsAffected = await _db.Organizations
+            .Where(x => x.Id == _orgId)
+            .ExecuteDeleteAsync();
         return rowsAffected > 0;
     }
 


### PR DESCRIPTION
### Description

Use `ExecuteDeleteAsync` to delete an organization rather than attempting to retrieve the organization.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] __
- [ ] __

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- [ ] __
- [ ] __
