### PR TITLE
Implement value comparers for the array conversions

### DIFF
--- a/src/Service/Storage/Ef/DbGlobalContext.cs
+++ b/src/Service/Storage/Ef/DbGlobalContext.cs
@@ -1,11 +1,13 @@
 using System.Text.Json;
 using Fido2NetLib.Objects;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Passwordless.Common.Constants;
 using Passwordless.Common.Extensions;
 using Passwordless.Common.Utils;
 using Passwordless.Service.EventLog.Models;
 using Passwordless.Service.Models;
+using Passwordless.Service.Storage.Ef.ValueComparers;
 
 namespace Passwordless.Service.Storage.Ef;
 
@@ -36,7 +38,8 @@ public abstract class DbGlobalContext : DbContext
             b.HasKey(x => new { x.Tenant, x.DescriptorId });
             b.Property(x => x.DescriptorTransports).HasConversion(
                 v => JsonSerializer.Serialize(v, jsonOptions),
-                v => JsonSerializer.Deserialize<AuthenticatorTransport[]>(v, jsonOptions));
+                v => JsonSerializer.Deserialize<AuthenticatorTransport[]>(v, jsonOptions))
+                .Metadata.SetValueComparer(new NullableArrayValueComparer<AuthenticatorTransport>());
         });
 
         modelBuilder.Entity<TokenKey>()
@@ -52,7 +55,8 @@ public abstract class DbGlobalContext : DbContext
             b.Property(x => x.Scopes)
                 .HasConversion(
                     v => string.Join(',', v),
-                    v => v.Split(',', StringSplitOptions.RemoveEmptyEntries));
+                    v => v.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                .Metadata.SetValueComparer(new ArrayValueComparer<string>());
         });
 
         modelBuilder.Entity<AliasPointer>()

--- a/src/Service/Storage/Ef/ValueComparers/ArrayValueComparer.cs
+++ b/src/Service/Storage/Ef/ValueComparers/ArrayValueComparer.cs
@@ -1,0 +1,8 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Passwordless.Service.Storage.Ef.ValueComparers;
+
+public sealed class ArrayValueComparer<T>() : ValueComparer<T[]>(
+    (c1, c2) => c1!.SequenceEqual(c2!),
+    c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+    c => c.ToArray());

--- a/src/Service/Storage/Ef/ValueComparers/NullableArrayValueComparer.cs
+++ b/src/Service/Storage/Ef/ValueComparers/NullableArrayValueComparer.cs
@@ -1,0 +1,8 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Passwordless.Service.Storage.Ef.ValueComparers;
+
+public sealed class NullableArrayValueComparer<T>() : ValueComparer<T[]?>(
+    (c1, c2) => (c1 == null && c2 == null) || c1!.SequenceEqual(c2!),
+    c => c != null ? c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())) : 0,
+    c => c != null ? c.ToArray() : null);

--- a/tests/Service.Tests/Storage/Ef/ValueComparers/ArrayValueComparerTests.cs
+++ b/tests/Service.Tests/Storage/Ef/ValueComparers/ArrayValueComparerTests.cs
@@ -1,0 +1,32 @@
+using Passwordless.Service.Storage.Ef.ValueComparers;
+
+namespace Passwordless.Service.Tests.Storage.Ef.ValueComparers;
+
+public class ArrayValueComparerTests
+{
+    [Fact]
+    public void NullableArrayValueComparer_ComparingSameArrays_ReturnsExpectedResult()
+    {
+        // Arrange
+        var sut = new NullableArrayValueComparer<string>();
+
+        // Act
+        var actual = sut.Equals(["a", "b"], ["a", "b"]);
+
+        // Assert
+        Assert.True(actual);
+    }
+
+    [Fact]
+    public void NullableArrayValueComparer_ComparingDifferentArrays_ReturnsExpectedResult()
+    {
+        // Arrange
+        var sut = new NullableArrayValueComparer<string>();
+
+        // Act
+        var actual = sut.Equals(["a", "b"], ["a", "c"]);
+
+        // Assert
+        Assert.False(actual);
+    }
+}

--- a/tests/Service.Tests/Storage/Ef/ValueComparers/NullableArrayValueComparerTests.cs
+++ b/tests/Service.Tests/Storage/Ef/ValueComparers/NullableArrayValueComparerTests.cs
@@ -1,0 +1,45 @@
+using Passwordless.Service.Storage.Ef.ValueComparers;
+
+namespace Passwordless.Service.Tests.Storage.Ef.ValueComparers;
+
+public class NullableArrayValueComparerTests
+{
+    [Fact]
+    public void NullableArrayValueComparer_Should_Compare_Nullable_Arrays()
+    {
+        // Arrange
+        var sut = new NullableArrayValueComparer<string>();
+
+        // Act
+        var actual = sut.Equals(null, null);
+
+        // Assert
+        Assert.True(actual);
+    }
+
+    [Fact]
+    public void NullableArrayValueComparer_ComparingSameArrays_ReturnsExpectedResult()
+    {
+        // Arrange
+        var sut = new NullableArrayValueComparer<string>();
+
+        // Act
+        var actual = sut.Equals(["a", "b"], ["a", "b"]);
+
+        // Assert
+        Assert.True(actual);
+    }
+
+    [Fact]
+    public void NullableArrayValueComparer_ComparingDifferentArrays_ReturnsExpectedResult()
+    {
+        // Arrange
+        var sut = new NullableArrayValueComparer<string>();
+
+        // Act
+        var actual = sut.Equals(["a", "b"], ["a", "c"]);
+
+        // Assert
+        Assert.False(actual);
+    }
+}


### PR DESCRIPTION
### Ticket

n/a

### Description

We are currently converting text fields into arrays with Entity Framework, but we are not implementing value comparers. This could impact change tracking: https://learn.microsoft.com/en-us/ef/core/modeling/value-comparers?tabs=ef5

### Shape

n/a

### Screenshots


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] Unit testing
