### PR TITLE
Delete expired organization events at midnight UTC.

### DIFF
--- a/src/AdminConsole/EventLog/Loggers/InternalEventStorage.cs
+++ b/src/AdminConsole/EventLog/Loggers/InternalEventStorage.cs
@@ -7,7 +7,12 @@ namespace Passwordless.AdminConsole.EventLog.Loggers;
 
 public interface IInternalEventLogStorageContext
 {
-    Task DeleteExpiredEvents(CancellationToken cancellationToken);
+    /// <summary>
+    /// Deletes expired events.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The amount of deleted events.</returns>
+    Task<int> DeleteExpiredEventsAsync(CancellationToken cancellationToken);
 }
 
 public class InternalEventLogStorageContext : IInternalEventLogStorageContext
@@ -25,7 +30,7 @@ public class InternalEventLogStorageContext : IInternalEventLogStorageContext
         _timeProvider = timeProvider;
     }
 
-    public async Task DeleteExpiredEvents(CancellationToken cancellationToken)
+    public async Task<int> DeleteExpiredEventsAsync(CancellationToken cancellationToken)
     {
         var organizations = await _db.OrganizationEvents
             .Select(x => x.OrganizationId)
@@ -49,6 +54,6 @@ public class InternalEventLogStorageContext : IInternalEventLogStorageContext
                 .Where(x => x.OrganizationId == organization.OrganizationId && x.PerformedAt < now.AddDays(-features.EventLoggingRetentionPeriod))
                 .ExecuteDeleteAsync();
         }
-        await _db.SaveChangesAsync(cancellationToken);
+        return await _db.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
### Description

Currently, the background services run at random times during the day depending on when the server has last restarted. This pull request makes that `organization delete background worker` runs at a fixed time during the day, 'midnight UTC'.

It will also return the amount of deleted records, for use with logging.

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- [ ] Run once

