### PR TITLE
Fix monthly quotas not applied directly on app creation

### DIFF
--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -112,13 +112,14 @@ public class SharedManagementService : ISharedManagementService
         var account = new AccountMetaInformation
         {
             AcountName = accountName,
-            AdminEmails = new[] { adminEmail },
+            AdminEmails = [adminEmail],
             CreatedAt = DateTime.UtcNow,
             Features = new AppFeature
             {
                 Tenant = accountName,
                 EventLoggingIsEnabled = options.EventLoggingIsEnabled,
                 EventLoggingRetentionPeriod = options.EventLoggingRetentionPeriod,
+                MagicLinkEmailMonthlyQuota = options.MagicLinkEmailMonthlyQuota,
                 MaxUsers = options.MaxUsers,
                 AllowAttestation = options.AllowAttestation,
                 IsGenerateSignInTokenEndpointEnabled = true

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -137,7 +137,7 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         var applicationName = CreateAppHelpers.GetApplicationName();
         using var appCreateResponse = await client.CreateApplicationAsync(applicationName, new CreateAppDto
         {
-            AdminEmail = "not-an-admin@email.com"
+            AdminEmail = "admin@email.com"
         });
         var appCreated = await appCreateResponse.Content.ReadFromJsonAsync<CreateAppResultDto>();
         client.AddSecretKey(appCreated!.ApiSecret1);

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -135,7 +135,10 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         using var client = api.CreateClient();
 
         var applicationName = CreateAppHelpers.GetApplicationName();
-        using var appCreateResponse = await client.CreateApplicationAsync(applicationName, "definitely-not@what-faker-will.generate");
+        using var appCreateResponse = await client.CreateApplicationAsync(applicationName, new CreateAppDto
+        {
+            AdminEmail = "not-an-admin@email.com"
+        });
         var appCreated = await appCreateResponse.Content.ReadFromJsonAsync<CreateAppResultDto>();
         client.AddSecretKey(appCreated!.ApiSecret1);
         await client.EnableMagicLinks("a_user");
@@ -161,7 +164,10 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
 
         const string emailAddress = "admin@email.com";
         var applicationName = CreateAppHelpers.GetApplicationName();
-        using var appCreateResponse = await client.CreateApplicationAsync(applicationName, emailAddress);
+        using var appCreateResponse = await client.CreateApplicationAsync(applicationName, new CreateAppDto
+        {
+            AdminEmail = emailAddress
+        });
         var appCreated = await appCreateResponse.Content.ReadFromJsonAsync<CreateAppResultDto>();
         client.AddSecretKey(appCreated!.ApiSecret1);
         await client.EnableMagicLinks("a_user");
@@ -176,7 +182,9 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
-    [Fact]
+    // Test assumes that the quota will eventually be exhausted.
+    // Timeout is used as fallback in case that assumption fails.
+    [Fact(Timeout = 60_000)]
     public async Task I_cannot_send_too_many_magic_link_emails_in_a_short_time()
     {
         // Arrange
@@ -194,8 +202,8 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         api.Time.Advance(TimeSpan.FromDays(365));
 
         // Act
-        var unsuccessfulResponse = default(HttpResponseMessage);
-        for (var i = 0; i < 1_000_000; i++)
+        HttpResponseMessage unsuccessfulResponse;
+        while (true)
         {
             var response = await client.PostAsJsonAsync("magic-link/send", request);
             if (!response.IsSuccessStatusCode)
@@ -216,7 +224,9 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         unsuccessfulResponse.Dispose();
     }
 
-    [Fact]
+    // Test assumes that the quota will eventually be exhausted.
+    // Timeout is used as fallback in case that assumption fails.
+    [Fact(Timeout = 60_000)]
     public async Task I_cannot_send_too_many_magic_link_emails_in_a_month()
     {
         // Arrange
@@ -224,7 +234,10 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         using var client = api.CreateClient();
 
         var applicationName = CreateAppHelpers.GetApplicationName();
-        using var appCreateResponse = await client.CreateApplicationAsync(applicationName);
+        using var appCreateResponse = await client.CreateApplicationAsync(applicationName, new CreateAppDto
+        {
+            MagicLinkEmailMonthlyQuota = 1000
+        });
         var appCreated = await appCreateResponse.Content.ReadFromJsonAsync<CreateAppResultDto>();
         client.AddSecretKey(appCreated!.ApiSecret1);
         await client.EnableMagicLinks("a_user");
@@ -234,8 +247,9 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         api.Time.Advance(TimeSpan.FromDays(365));
 
         // Act
-        var unsuccessfulResponse = default(HttpResponseMessage);
-        for (var i = 0; i < 1_000_000; i++)
+        var successfulResponseCount = 0;
+        HttpResponseMessage unsuccessfulResponse;
+        while (true)
         {
             var response = await client.PostAsJsonAsync("magic-link/send", request);
             if (!response.IsSuccessStatusCode)
@@ -249,9 +263,11 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
             }
 
             api.Time.Advance(TimeSpan.FromMinutes(1));
+            successfulResponseCount++;
         }
 
         // Assert
+        successfulResponseCount.Should().Be(1000);
         unsuccessfulResponse.Should().NotBeNull();
         unsuccessfulResponse!.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
 
@@ -260,7 +276,9 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         details!.Type.Should().Contain("magic_link_email_quota_exceeded");
     }
 
-    [Fact]
+    // Test assumes that the quota will eventually be exhausted.
+    // Timeout is used as fallback in case that assumption fails.
+    [Fact(Timeout = 60_000)]
     public async Task I_can_send_a_magic_link_email_after_enough_time_passed_since_the_monthly_quota_was_exceeded()
     {
         // Arrange
@@ -277,7 +295,7 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         // Skip all limitations for new applications
         api.Time.Advance(TimeSpan.FromDays(365));
 
-        for (var i = 0; i < 1_000_000; i++)
+        while (true)
         {
             using var initialResponse = await client.PostAsJsonAsync("magic-link/send", request);
             if (!initialResponse.IsSuccessStatusCode)

--- a/tests/Api.IntegrationTests/Helpers/App/CreateAppHelpers.cs
+++ b/tests/Api.IntegrationTests/Helpers/App/CreateAppHelpers.cs
@@ -17,7 +17,7 @@ public static class CreateAppHelpers
             client.AddManagementKey();
         }
 
-        return client.PostAsJsonAsync($"/admin/apps/{applicationName}/create", options);
+        return client.PostAsJsonAsync($"/admin/apps/{applicationName}/create", options ?? new CreateAppDto());
     }
 
     public static Task<HttpResponseMessage> CreateApplicationAsync(this HttpClient client)

--- a/tests/Api.IntegrationTests/Helpers/App/CreateAppHelpers.cs
+++ b/tests/Api.IntegrationTests/Helpers/App/CreateAppHelpers.cs
@@ -10,17 +10,14 @@ public static class CreateAppHelpers
     public static Task<HttpResponseMessage> CreateApplicationAsync(
         this HttpClient client,
         string applicationName,
-        string? adminEmail = null)
+        CreateAppDto? options = null)
     {
         if (!client.DefaultRequestHeaders.Contains("ManagementKey"))
         {
             client.AddManagementKey();
         }
 
-        return client.PostAsJsonAsync($"/admin/apps/{applicationName}/create", new CreateAppDto
-        {
-            AdminEmail = adminEmail ?? "test-admin@passwordless.dev"
-        });
+        return client.PostAsJsonAsync($"/admin/apps/{applicationName}/create", options);
     }
 
     public static Task<HttpResponseMessage> CreateApplicationAsync(this HttpClient client)

--- a/tests/Api.IntegrationTests/Helpers/App/CreateAppHelpers.cs
+++ b/tests/Api.IntegrationTests/Helpers/App/CreateAppHelpers.cs
@@ -17,7 +17,15 @@ public static class CreateAppHelpers
             client.AddManagementKey();
         }
 
-        return client.PostAsJsonAsync($"/admin/apps/{applicationName}/create", options ?? new CreateAppDto());
+        var actualOptions = options ?? new CreateAppDto();
+
+        if (string.IsNullOrWhiteSpace(actualOptions.AdminEmail))
+            actualOptions.AdminEmail = "admin@email.com";
+
+        if (actualOptions.MagicLinkEmailMonthlyQuota == 0)
+            actualOptions.MagicLinkEmailMonthlyQuota = 1000;
+
+        return client.PostAsJsonAsync($"/admin/apps/{applicationName}/create", actualOptions);
     }
 
     public static Task<HttpResponseMessage> CreateApplicationAsync(this HttpClient client)


### PR DESCRIPTION
### Ticket

N/A

### Description

Previously, the monthly quotas were set either when the application changed billing tiers or during the initial migration. New applications created after the initial migrations did not have the correct quota set.

### Shape

N/A

### Screenshots

N/A

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Updated tests

I did the following to ensure that my changes did not introduce new security vulnerabilities:
- N/A
