### PR TITLE
PAS-393 | AppId availability check is not displayed in the UI correctly

### DIFF
--- a/src/AdminConsole/Pages/Organization/CreateApplication.cshtml
+++ b/src/AdminConsole/Pages/Organization/CreateApplication.cshtml
@@ -17,12 +17,7 @@
                     <div v-cloak :class="{ invisible: !appId }" class=" small">
                         <input asp-for="Form.Id" type="hidden" :value="parsedAppId"/>
                         Your app id is:
-                        <span   
-                            class="parsed_tenant_name">
-                            {{
-                            parsedAppId
-                            }}
-                        </span>
+                        <span class="parsed_tenant_name">{{parsedAppId}}</span>
                         <span v-if="availability == 'available'"> ✅ Available</span>
                         <span v-if="availability == 'not-available'"> ⚠️ Unavailable</span>
 
@@ -99,7 +94,12 @@
                         "Content-Type": "application/json",
                     }
                 });
-                return res.ok;
+                const data = await res.json();
+                if (!res.ok) {
+                    console.error("An unexpected error occurred. Cannot verify whether appid is available.")
+                    return false;
+                }
+                return data.available === true;
             }
 
             watch(appId, async () => {


### PR DESCRIPTION
### Ticket
- Closes [PAS-393](https://bitwarden.atlassian.net/browse/PAS-393)

### Description

Before, the Api was returning a 409 when there was already an app with the same appid registered. However, the AdminConsole was returning a 500 status code in the front-end.

This was eventually resolved to always return a 200 status code with the body below:

`{ "available": true }`

What we forgot to fix at the time was the Javascript portion which was just checking whether the received response was successful, i.e. `2xx`.

This pull request makes sure we're reading the received body and act upon the value of the received property accordingly.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots

<img width="521" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/047b90a2-7e7f-419f-a08d-12125a77ad31">

<img width="521" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/5d5d4c44-248a-46d4-9d9a-5d8fa447833d">

<img width="849" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/1fc84ebb-3032-4162-b49b-18aa6bd79dbe">

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Testing changes in admin console.

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-393]: https://bitwarden.atlassian.net/browse/PAS-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ