### PR TITLE
PAS-202 | Prevent Swagger from crashing with duplicate authorization policies.

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -33,7 +33,7 @@ builder.Services.AddSwaggerGen(swagger =>
     swagger.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Passwordless.Api.xml"), true);
     swagger.DocInclusionPredicate((docName, apiDesc) =>
     {
-        var policy = (AuthorizationPolicy?)apiDesc.ActionDescriptor.EndpointMetadata.SingleOrDefault(x => x.GetType() == typeof(AuthorizationPolicy));
+        var policy = (AuthorizationPolicy?)apiDesc.ActionDescriptor.EndpointMetadata.FirstOrDefault(x => x.GetType() == typeof(AuthorizationPolicy));
         if (policy == null)
         {
             return false;


### PR DESCRIPTION
### Ticket

- Closes [PAS-202](https://bitwarden.atlassian.net/browse/PAS-202)

### Description

There are currently two authorization policies applied to the magic links endpoint which is causing swagger to crash.

Closed by: https://github.com/bitwarden/passwordless-server/pull/487

This pull request would prevent it from happening again.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
