### PR TITLE
Add range to TTL

### DIFF
--- a/src/Api/Endpoints/Magic.cs
+++ b/src/Api/Endpoints/Magic.cs
@@ -15,24 +15,29 @@ namespace Passwordless.Api.Endpoints;
 
 public static class MagicEndpoints
 {
+    /// <summary>
+    /// Name of the Magic Links Rate Limiter Policy
+    /// </summary>
     public const string RateLimiterPolicy = nameof(MagicEndpoints);
 
+    /// <summary>
+    /// Adds a rate limiter policy for the MagicEndpoints. Each tenant will have its own partition.
+    /// </summary>
+    /// <param name="builder">The RateLimiterOptions builder.</param>
     public static void AddMagicRateLimiterPolicy(this RateLimiterOptions builder) =>
         builder.AddPolicy(RateLimiterPolicy, context =>
         {
             var tenant = context.User.FindFirstValue(CustomClaimTypes.AccountName) ?? "<global>";
 
             return RateLimitPartition.GetFixedWindowLimiter(tenant, _ =>
-                new FixedWindowRateLimiterOptions
-                {
-                    Window = TimeSpan.FromMinutes(5),
-                    PermitLimit = 10,
-                    QueueLimit = 0,
-                    AutoReplenishment = true
-                }
+                new FixedWindowRateLimiterOptions { Window = TimeSpan.FromMinutes(5), PermitLimit = 10, QueueLimit = 0, AutoReplenishment = true }
             );
         });
 
+    /// <summary>
+    /// Maps the magic link endpoints.
+    /// </summary>
+    /// <param name="app">The <see cref="IEndpointRouteBuilder"/> object.</param>
     public static void MapMagicEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/magic-link")

--- a/src/Common/MagicLinks/Models/SendMagicLinkRequest.cs
+++ b/src/Common/MagicLinks/Models/SendMagicLinkRequest.cs
@@ -19,7 +19,11 @@ public class SendMagicLinkRequest
     public string UserId { get; init; }
 
     /// <summary>
-    /// Number of seconds the magic link will be valid for.
+    /// Represents the time to live (TTL) of a magic link in seconds.
     /// </summary>
+    /// <remarks>
+    /// The TTL is the lifespan of a magic link, i.e., the duration for which the link is valid.
+    /// </remarks>
+    [Range(1, 604800)]
     public int? TimeToLive { get; init; }
 }

--- a/src/Service/Models/SigninTokenRequest.cs
+++ b/src/Service/Models/SigninTokenRequest.cs
@@ -16,6 +16,7 @@ public class SigninTokenRequest : RequestBase
     /// </summary>
     [JsonPropertyName("timeToLive")]
     [Obsolete("This property is only used for serialization.")]
+    [Range(1, 604800)]
     public int? TimeToLiveSeconds { get; init; }
 
     [JsonIgnore]


### PR DESCRIPTION
### Ticket
- Closes [PAS-373](https://bitwarden.atlassian.net/browse/PAS-373)


### Description
Currently there is no restriction for TTL with both MGATs and Magic Links. This adds range of valid values of 1 second to 7 days.

### Shape
Adds min value of 1 second and max value of 7 days to Magic Links and MGATs via the RangeValidationAttribute.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Ran tests

I did the following to ensure that my changes do not introduce security vulnerabilities:
- changes were limited to adding validation to request models.


[PAS-373]: https://bitwarden.atlassian.net/browse/PAS-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ