### PR TITLE
Initialize AC Quota

### DIFF
--- a/src/AdminConsole/Components/Pages/Initialize.razor
+++ b/src/AdminConsole/Components/Pages/Initialize.razor
@@ -1,15 +1,14 @@
 @page "/initialize"
-@attribute [AllowAnonymous]
-
-@using Passwordless.AdminConsole.Identity
 @using Microsoft.EntityFrameworkCore
 @using Microsoft.Extensions.Options
-@using Passwordless.Common.Models.Apps
 @using Passwordless.AdminConsole.Services.PasswordlessManagement
+@using Passwordless.Common.Models.Apps
 @using Passwordless.AdminConsole.Db
+@using Passwordless.AdminConsole.Identity
 @using Microsoft.AspNetCore.Identity
 @using Passwordless.AdminConsole.Models
 @using System.ComponentModel.DataAnnotations
+@attribute [AllowAnonymous]
 
 @inject ISetupService SetupService
 @inject IOptions<PasswordlessManagementOptions> ManagementOptions
@@ -113,7 +112,8 @@
 
             using var response = await http.PostAsJsonAsync("/admin/apps/adminconsole/create", new CreateAppDto
             {
-                AdminEmail = Form.AdminEmail
+                AdminEmail = Form.AdminEmail,
+                MagicLinkEmailMonthlyQuota = 2000
             });
 
             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
### Ticket

- Closes [PAS-375](https://bitwarden.atlassian.net/browse/PAS-375)



### Description
Forgot to set the default quota for admin console.

### Shape
Added the default value in the code.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Manually testing through self hosting. Can initialize AdminConsole

[PAS-375]: https://bitwarden.atlassian.net/browse/PAS-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ