### PR TITLE
PAS-375 | Magic links <24h condition breaking self-hosting

### DIFF
--- a/src/AdminConsole/Components/Pages/Initialize.razor
+++ b/src/AdminConsole/Components/Pages/Initialize.razor
@@ -10,6 +10,7 @@
 @using Microsoft.AspNetCore.Identity
 @using Passwordless.AdminConsole.Models
 @using System.ComponentModel.DataAnnotations
+@using Passwordless.AdminConsole.Billing.Configuration
 
 @inject ISetupService SetupService
 @inject IOptions<PasswordlessManagementOptions> ManagementOptions
@@ -110,10 +111,13 @@
             using var http = new HttpClient();
             http.BaseAddress = new Uri(ManagementOptions.Value.InternalApiUrl);
             http.DefaultRequestHeaders.Add("ManagementKey", ManagementOptions.Value.ManagementKey);
-
+            
             using var response = await http.PostAsJsonAsync("/admin/apps/adminconsole/create", new CreateAppDto
             {
-                AdminEmail = Form.AdminEmail
+                AdminEmail = Form.AdminEmail,
+                MagicLinkEmailMonthlyQuota = 2000,
+                AllowAttestation = false,
+                EventLoggingIsEnabled = false
             });
 
             response.EnsureSuccessStatusCode();

--- a/src/AdminConsole/Components/Pages/Initialize.razor
+++ b/src/AdminConsole/Components/Pages/Initialize.razor
@@ -10,7 +10,6 @@
 @using Microsoft.AspNetCore.Identity
 @using Passwordless.AdminConsole.Models
 @using System.ComponentModel.DataAnnotations
-@using Passwordless.AdminConsole.Billing.Configuration
 
 @inject ISetupService SetupService
 @inject IOptions<PasswordlessManagementOptions> ManagementOptions
@@ -111,13 +110,10 @@
             using var http = new HttpClient();
             http.BaseAddress = new Uri(ManagementOptions.Value.InternalApiUrl);
             http.DefaultRequestHeaders.Add("ManagementKey", ManagementOptions.Value.ManagementKey);
-            
+
             using var response = await http.PostAsJsonAsync("/admin/apps/adminconsole/create", new CreateAppDto
             {
-                AdminEmail = Form.AdminEmail,
-                MagicLinkEmailMonthlyQuota = 2000,
-                AllowAttestation = false,
-                EventLoggingIsEnabled = false
+                AdminEmail = Form.AdminEmail
             });
 
             response.EnsureSuccessStatusCode();

--- a/src/Service/MagicLinks/MagicLinkService.cs
+++ b/src/Service/MagicLinks/MagicLinkService.cs
@@ -22,18 +22,6 @@ public class MagicLinkService(
         var account = await tenantStorage.GetAccountInformation();
         var accountAge = now - account.CreatedAt;
 
-        // Applications created less than 24 hours ago can only send magic links to the admin email address
-        if (accountAge < TimeSpan.FromHours(24) &&
-            !account.AdminEmails.Contains(request.EmailAddress.Address, StringComparer.OrdinalIgnoreCase))
-        {
-            throw new ApiException(
-                "magic_link_email_admin_address_only",
-                "Because your application has been created less than 24 hours ago, " +
-                "you can only request magic links to the admin email address.",
-                403
-            );
-        }
-
         var maxQuota = (await tenantStorage.GetAppFeaturesAsync()).MagicLinkEmailMonthlyQuota;
 
         // Reduce the quota for newly created applications

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -128,34 +128,6 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
     }
 
     [Fact]
-    public async Task I_cannot_send_a_magic_link_email_to_a_non_admin_address_if_the_application_is_too_new()
-    {
-        // Arrange
-        await using var api = await apiFixture.CreateApiAsync(testOutput);
-        using var client = api.CreateClient();
-
-        var applicationName = CreateAppHelpers.GetApplicationName();
-        using var appCreateResponse = await client.CreateApplicationAsync(applicationName, new CreateAppDto
-        {
-            AdminEmail = "admin@email.com"
-        });
-        var appCreated = await appCreateResponse.Content.ReadFromJsonAsync<CreateAppResultDto>();
-        client.AddSecretKey(appCreated!.ApiSecret1);
-        await client.EnableMagicLinks("a_user");
-        var request = _requestFaker.Generate();
-
-        // Act
-        using var response = await client.PostAsJsonAsync("magic-link/send", request);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-
-        var details = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        details.Should().NotBeNull();
-        details!.Type.Should().Contain("magic_link_email_admin_address_only");
-    }
-
-    [Fact]
     public async Task I_can_send_a_magic_link_email_to_an_admin_address_even_if_the_application_is_too_new()
     {
         // Arrange


### PR DESCRIPTION
### Description

When you create a new self-hosting environment, you go through the '/initialize' page where a new organization and 'adminconsole' application will be created. However, when you then successfully proceed to the signup page, you essentially cannot register the actual organization that will hold all your applications. So basically the first 24 hours every customer will be blocked from doing anything at all with their self-hosting environment.

This condition will likely also cause a lot of problems during development if potential customers want to have multiple developers or admins work together during the first day.

### Shape

It would be better to adjust the enforcement quota based on application age. And gradually increase as time passes.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
