### PR TITLE
Handle DbConcurrencyException for reporting.

### DIFF
--- a/src/Api/Reporting/Background/ActiveUserReportingBackgroundService.cs
+++ b/src/Api/Reporting/Background/ActiveUserReportingBackgroundService.cs
@@ -30,8 +30,9 @@ public sealed class ActiveUserReportingBackgroundService : BasePeriodicBackgroun
         {
             result = await reportingService.UpdatePeriodicActiveUserReportsAsync();
         }
-        catch (DBConcurrencyException)
+        catch (Exception e)
         {
+            Logger.LogError(e, "Error updating periodic active user reports.");
             return;
         }
         Logger.LogInformation("{BackgroundService} updated {Records}.", nameof(ActiveUserReportingBackgroundService), result);

--- a/src/Api/Reporting/Background/UsersCountReportingBackgroundService.cs
+++ b/src/Api/Reporting/Background/UsersCountReportingBackgroundService.cs
@@ -30,8 +30,9 @@ public sealed class PeriodicCredentialReportsBackgroundService : BasePeriodicBac
         {
             result = await reportingService.UpdatePeriodicCredentialReportsAsync();
         }
-        catch (DBConcurrencyException)
+        catch (Exception e)
         {
+            Logger.LogError(e, "Error updating periodic credential reports.");
             return;
         }
         Logger.LogInformation("{BackgroundService} updated {Records}.", nameof(PeriodicCredentialReportsBackgroundService), result);


### PR DESCRIPTION
### Ticket

n/a

### Description

When we have multiple instances running. It's executed multiple times around the same time. This prevents an exception/error from being logged. Changing the logging level to warning as it was caught.

In an ideal situation, we'd have only one master service to sync or multiple with each syncing a subset/partition.
