### PR TITLE
Allow AC to send magic links

### DIFF
--- a/src/Service/MagicLinks/MagicLinkService.cs
+++ b/src/Service/MagicLinks/MagicLinkService.cs
@@ -15,7 +15,7 @@ public class MagicLinkService(
     IEventLogger eventLogger)
 {
     private static readonly string[] AdminConsole = ["admin", "adminconsole"];
-    
+
     private async Task EnforceQuotaAsync(MagicLinkTokenRequest request)
     {
         var now = timeProvider.GetUtcNow();

--- a/src/Service/MagicLinks/MagicLinkService.cs
+++ b/src/Service/MagicLinks/MagicLinkService.cs
@@ -14,8 +14,6 @@ public class MagicLinkService(
     IMailProvider mailProvider,
     IEventLogger eventLogger)
 {
-    private static readonly string[] AdminConsole = ["admin", "adminconsole"];
-
     private async Task EnforceQuotaAsync(MagicLinkTokenRequest request)
     {
         var now = timeProvider.GetUtcNow();
@@ -65,9 +63,9 @@ public class MagicLinkService(
         }
     }
 
-    private static bool IsAdminConsole(AccountMetaInformation account) =>
-        string.Equals(account.Tenant, "admin", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(account.Tenant, "adminconsole", StringComparison.OrdinalIgnoreCase);
+    private static bool IsAdminConsole(PerTenant account) =>
+        string.Equals(account.Tenant, "admin", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(account.Tenant, "adminconsole", StringComparison.OrdinalIgnoreCase);
 
     public async Task SendMagicLinkAsync(MagicLinkTokenRequest request)
     {

--- a/src/Service/MagicLinks/MagicLinkService.cs
+++ b/src/Service/MagicLinks/MagicLinkService.cs
@@ -65,7 +65,9 @@ public class MagicLinkService(
         }
     }
 
-    private static bool IsAdminConsole(AccountMetaInformation account) => AdminConsole.Contains(account.Tenant);
+    private static bool IsAdminConsole(AccountMetaInformation account) =>
+        string.Equals(account.Tenant, "admin", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(account.Tenant, "adminconsole", StringComparison.OrdinalIgnoreCase);
 
     public async Task SendMagicLinkAsync(MagicLinkTokenRequest request)
     {


### PR DESCRIPTION
### Ticket
- Closes [PAS-375](https://bitwarden.atlassian.net/browse/PAS-375)

### Description
AdminConsole is being restricted by how recently it was created in new self hosted instances. This checks if the requesting application is admin console by tenant name.

### Shape
Adds an `IsAdminConsole` check when enforcing the 24h limit quota.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- ran unit tests.

I did the following to ensure that my changes do not introduce security vulnerabilities:
- ensured quota enforcement was kept in place.


[PAS-375]: https://bitwarden.atlassian.net/browse/PAS-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ