### PR TITLE
`libsodium` is missing in the alpine test image.

### DIFF
--- a/Api.dockerfile
+++ b/Api.dockerfile
@@ -39,7 +39,7 @@ EXPOSE $ASPNETCORE_HTTP_PORTS
 
 # Alpine image doesn't come with the ICU libraries pre-installed, so we need to install them manually.
 # Technically, we shouldn't need globalization support in the API, but some EF queries fail without it at the moment.
-RUN apk add --no-cache icu-libs
+RUN apk add --no-cache icu-libs libsodium
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # Use the default non-root user for the app.

--- a/Api.dockerfile
+++ b/Api.dockerfile
@@ -39,6 +39,7 @@ EXPOSE $ASPNETCORE_HTTP_PORTS
 
 # Alpine image doesn't come with the ICU libraries pre-installed, so we need to install them manually.
 # Technically, we shouldn't need globalization support in the API, but some EF queries fail without it at the moment.
+# `libsodium` is required by the `NSec.Cryptography` package.
 RUN apk add --no-cache icu-libs libsodium
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 


### PR DESCRIPTION
### Description

The alpine image is missing `libsodium`, causing unit & integration tests to fail.

```
[06:19:42 INF] HTTP POST /admin/apps/app84c66feff0c44cc2bbc5199c1615f259/create responded 200 in 18.2468 ms
fail: Passwordless.Api.Helpers.LoggingMiddleware[10000]
      The API has encountered an error
      System.PlatformNotSupportedException: Could not initialize platform-specific components. NSec may not be supported on this platform. See https://nsec.rocks/docs/install for more information.
       ---> System.DllNotFoundException: Unable to load shared library 'libsodium' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
      Error loading shared library ld-linux-aarch64.so.1: No such file or directory (needed by /opt/app/libsodium.so)
      Error loading shared library libsodium.so: No such file or directory
      Error loading shared library /opt/app/liblibsodium.so: No such file or directory
      Error loading shared library liblibsodium.so: No such file or directory
      Error loading shared library /opt/app/libsodium: No such file or directory
      Error loading shared library libsodium: No such file or directory
      Error loading shared library /opt/app/liblibsodium: No such file or directory
      Error loading shared library liblibsodium: No such file or directory
      
         at Interop.Libsodium.sodium_library_version_major()
         at NSec.Cryptography.Sodium.InitializeCore()
         --- End of inner exception stack trace ---
         at NSec.Cryptography.Sodium.InitializeCore()
         at NSec.Cryptography.Algorithm..ctor()
         at NSec.Cryptography.KeyDerivationAlgorithm..ctor(Boolean supportsSalt, Int32 maxCount)
         at NSec.Cryptography.KeyDerivationAlgorithm2..ctor(Boolean supportsSalt, Int32 maxCount, Int32 pseudorandomKeySize)
         at NSec.Cryptography.HkdfSha256..ctor()
         at NSec.Cryptography.KeyDerivationAlgorithm.get_HkdfSha256()
         at Passwordless.Service.TokenService.DeriveKey(String tenant, IConfiguration config, Byte[] keyBytes) in /tmp/app/src/Service/TokenService.cs:line 49
         at Passwordless.Service.TokenService.GetRandomKeyAsync() in /tmp/app/src/Service/TokenService.cs:line 146
         at Passwordless.Service.TokenService.EncodeTokenAsync[T](T token, String prefix, Boolean contractless) in /tmp/app/src/Service/TokenService.cs:line 162
         at Passwordless.Service.Fido2Service.CreateSigninTokenAsync(SigninTokenRequest request) in /tmp/app/src/Service/Fido2Service.cs:line 287
         at Passwordless.Api.Endpoints.SigninEndpoints.<>c.<<MapSigninEndpoints>b__1_0>d.MoveNext() in /tmp/app/src/Api/Endpoints/Signin.cs:line 34
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.<TaskOfTToValueTaskOfObject>g__ExecuteAwaited|92_0[T](Task`1 task)
         at Microsoft.AspNetCore.Http.ValidationFilterRouteHandlerBuilderExtensions.<>c__DisplayClass0_2`1.<<WithParameterValidation>b__2>d.MoveNext() in /_/src/MinimalApis.Extensions/Filters/ValidationFilterRouteHandlerBuilderExtensions.cs:line 194
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.<ExecuteValueTaskOfObject>g__ExecuteAwaited|129_0(ValueTask`1 valueTask, HttpContext httpContext, JsonTypeInfo`1 jsonTypeInfo)
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.<>c__DisplayClass102_2.<<HandleRequestBodyAndCompileRequestDelegateForJson>b__2>d.MoveNext()
      --- End of stack trace from previous location ---
         at Passwordless.Api.Helpers.FriendlyExceptionsMiddleware.SafeNextAsync(HttpContext context) in /tmp/app/src/Api/Helpers/FriendlyExceptionsMiddleware.cs:line 34
```

### Shape

`NSec.Cryptography` is implicitly installed in our solution through the `Fido2` library.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
