### PR TITLE
Track the `Client-Version` header in the API.

### DIFF
--- a/src/Api/datadog.json
+++ b/src/Api/datadog.json
@@ -2,5 +2,6 @@
     "DD_SITE": "datadoghq.eu",
     "DD_ENV": "pass-any",
     "DD_VERSION": "0.0.0",
-    "DD_LOGS_INJECTION": true
+    "DD_LOGS_INJECTION": true,
+    "DD_TRACE_HEADER_TAGS": "Client-Version"
 }


### PR DESCRIPTION
### Description

Allows us to track the `Client-Version` header in Datadog. Relevant for when errors happen due to a specific Android or JS SDK.

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
