### PR TITLE
Hotswap Stripe API secrets when they are updated.

### DIFF
--- a/src/AdminConsole/Billing/BackgroundServices/StripeConfigurationUpdaterBackgroundService.cs
+++ b/src/AdminConsole/Billing/BackgroundServices/StripeConfigurationUpdaterBackgroundService.cs
@@ -5,7 +5,8 @@ using Stripe;
 namespace Passwordless.AdminConsole.Billing.BackgroundServices;
 
 public class StripeConfigurationUpdaterBackgroundService(
-    IOptionsMonitor<BillingOptions> OptionsMonitor) : BackgroundService
+    IOptionsMonitor<BillingOptions> OptionsMonitor,
+    ILogger<StripeConfigurationUpdaterBackgroundService> Logger) : BackgroundService
 {
     private IDisposable? _onChangeListener;
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
@@ -17,7 +18,11 @@ public class StripeConfigurationUpdaterBackgroundService(
 
     private void OnOptionsChanged(BillingOptions options, string? arg2)
     {
-        StripeConfiguration.ApiKey = options.ApiKey;
+        if (StripeConfiguration.ApiKey != options.ApiKey)
+        {
+            StripeConfiguration.ApiKey = options.ApiKey;
+            Logger.LogInformation("Stripe API key updated.");
+        }
     }
 
     public override void Dispose()

--- a/src/AdminConsole/Billing/BackgroundServices/StripeConfigurationUpdaterBackgroundService.cs
+++ b/src/AdminConsole/Billing/BackgroundServices/StripeConfigurationUpdaterBackgroundService.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Options;
+using Passwordless.AdminConsole.Billing.Configuration;
+using Stripe;
+
+namespace Passwordless.AdminConsole.Billing.BackgroundServices;
+
+public class StripeConfigurationUpdaterBackgroundService(
+    IOptionsMonitor<BillingOptions> OptionsMonitor) : BackgroundService
+{
+    private IDisposable? _onChangeListener;
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        StripeConfiguration.ApiKey = OptionsMonitor.CurrentValue.ApiKey;
+        _onChangeListener = OptionsMonitor.OnChange(OnOptionsChanged);
+        return Task.CompletedTask;
+    }
+
+    private void OnOptionsChanged(BillingOptions options, string? arg2)
+    {
+        StripeConfiguration.ApiKey = options.ApiKey;
+    }
+
+    public override void Dispose()
+    {
+        _onChangeListener?.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/AdminConsole/Billing/BillingBootstrap.cs
+++ b/src/AdminConsole/Billing/BillingBootstrap.cs
@@ -1,6 +1,8 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Passwordless.AdminConsole.Billing.BackgroundServices;
 using Passwordless.AdminConsole.Billing.Configuration;
 using Passwordless.AdminConsole.Services;
+using Passwordless.Common.Configuration;
 using Stripe;
 
 namespace Passwordless.AdminConsole.Billing;
@@ -16,13 +18,13 @@ public static class BillingBootstrap
         builder.Services.AddHostedService<UserCountUpdaterBackgroundService>();
 
         // Todo: Improve this self-hosting story.
-        if (builder.Configuration.GetValue("SelfHosted", false))
+        if (builder.Configuration.IsSelfHosted())
         {
             builder.Services.AddScoped<ISharedBillingService, NoOpBillingService>();
         }
         else
         {
-            StripeConfiguration.ApiKey = builder.Configuration["Stripe:ApiKey"];
+            builder.Services.AddHostedService<StripeConfigurationUpdaterBackgroundService>();
             builder.Services.AddScoped<ISharedBillingService, SharedStripeBillingService>();
             builder.Services.AddHostedService<MeteredBillingBackgroundService>();
         }

--- a/src/AdminConsole/Pages/Billing/webhook.cshtml.cs
+++ b/src/AdminConsole/Pages/Billing/webhook.cshtml.cs
@@ -14,12 +14,12 @@ namespace Passwordless.AdminConsole.Pages.Billing;
 public class Webhook : PageModel
 {
     private readonly ISharedBillingService _sharedBillingService;
-    private readonly BillingOptions _billingOptions;
+    private readonly IOptionsSnapshot<BillingOptions> _billingOptions;
 
-    public Webhook(ISharedBillingService sharedBillingService, IOptions<BillingOptions> billingOptions)
+    public Webhook(ISharedBillingService sharedBillingService, IOptionsSnapshot<BillingOptions> billingOptions)
     {
         _sharedBillingService = sharedBillingService;
-        _billingOptions = billingOptions.Value;
+        _billingOptions = billingOptions;
     }
 
     public async Task<IActionResult> OnPost()
@@ -31,7 +31,7 @@ public class Webhook : PageModel
             stripeEvent = EventUtility.ConstructEvent(
                 json,
                 Request.Headers["Stripe-Signature"],
-                _billingOptions.WebhookSecret
+                _billingOptions.Value.WebhookSecret
             );
             Console.WriteLine($"Webhook notification with type: {stripeEvent.Type} found for {stripeEvent.Id}");
         }


### PR DESCRIPTION
### Description

This pull request allows that Stripe API secrets are updated automatically without having to restart the Passwordless.dev admin console in production. Effectively reducing down-time.

The Stripe .NET SDK unfortunately does not support the options pattern.

### Shape

The background service remains active during the entire application life cycle until it shuts down.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Tested for Self-hosting
- Tested for Cloud

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
