### PR TITLE
PAS-202 | OpenAPI improvements

### DIFF
--- a/src/Api/Endpoints/Alias.cs
+++ b/src/Api/Endpoints/Alias.cs
@@ -1,7 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Models;
 using Passwordless.Api.OpenApi;
+using Passwordless.Common.Constants;
 using Passwordless.Service;
 using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.Helpers;
@@ -28,6 +32,9 @@ public static class AliasEndpoints
     /// <summary>
     /// Sets one or more aliases for an existing user and removes existing aliases that are not included in the request.
     /// </summary>
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
+    [ProducesErrorResponseType(typeof(ProblemDetails))]
     public static async Task<IResult> SetAliasAsync(
         [FromBody] AliasPayload payload,
         IFido2Service fido2Service,
@@ -43,6 +50,8 @@ public static class AliasEndpoints
     /// <summary>
     /// Lists all aliases for a given user.
     /// </summary>
+    [ProducesResponseType(typeof(ListResponse<AliasPointer>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> ListAliasesAsync(
         [FromQuery] string userId,
         IFido2Service fido2Service)

--- a/src/Api/Endpoints/Alias.cs
+++ b/src/Api/Endpoints/Alias.cs
@@ -1,11 +1,9 @@
 ﻿using System.Net;
 using System.Net.Mime;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Models;
 using Passwordless.Api.OpenApi;
-using Passwordless.Common.Constants;
 using Passwordless.Service;
 using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.Helpers;

--- a/src/Api/Endpoints/Apps.cs
+++ b/src/Api/Endpoints/Apps.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Helpers;
@@ -222,6 +224,8 @@ public static class AppsEndpoints
     /// <summary>
     /// Change the configuration or features.
     /// </summary>
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> SetFeaturesAsync(
         SetFeaturesRequest payload,
         IApplicationService service)

--- a/src/Api/Endpoints/Authenticators.cs
+++ b/src/Api/Endpoints/Authenticators.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.OpenApi;
@@ -42,6 +44,8 @@ public static class AuthenticatorsEndpoints
     /// <param name="featureContextProvider"></param>
     /// <returns></returns>
     /// <exception cref="ApiException"></exception>
+    [ProducesResponseType(typeof(IEnumerable<ConfiguredAuthenticatorResponse>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> ListConfiguredAuthenticatorsAsync(
         [AsParameters] ConfiguredAuthenticatorRequest request,
         IApplicationService service,
@@ -65,6 +69,9 @@ public static class AuthenticatorsEndpoints
     /// <param name="eventLogger"></param>
     /// <returns></returns>
     /// <exception cref="ApiException"></exception>
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
+    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.Forbidden, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> AddAuthenticatorsAsync(
         [FromBody] AddAuthenticatorsRequest request,
         IApplicationService service,
@@ -91,6 +98,9 @@ public static class AuthenticatorsEndpoints
     /// <param name="eventLogger"></param>
     /// <returns></returns>
     /// <exception cref="ApiException"></exception>
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
+    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.Forbidden, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> RemoveAuthenticatorsAsync(
         [FromBody] RemoveAuthenticatorsRequest request,
         IApplicationService service,

--- a/src/Api/Endpoints/Authenticators.cs
+++ b/src/Api/Endpoints/Authenticators.cs
@@ -71,7 +71,6 @@ public static class AuthenticatorsEndpoints
     /// <exception cref="ApiException"></exception>
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
-    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.Forbidden, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> AddAuthenticatorsAsync(
         [FromBody] AddAuthenticatorsRequest request,
         IApplicationService service,
@@ -100,7 +99,6 @@ public static class AuthenticatorsEndpoints
     /// <exception cref="ApiException"></exception>
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
-    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.Forbidden, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> RemoveAuthenticatorsAsync(
         [FromBody] RemoveAuthenticatorsRequest request,
         IApplicationService service,

--- a/src/Api/Endpoints/Authenticators.cs
+++ b/src/Api/Endpoints/Authenticators.cs
@@ -22,12 +22,7 @@ public static class AuthenticatorsEndpoints
             .RequireSecretKey()
             .WithTags(OpenApiTags.Authenticators);
 
-        group.MapGet("/list", ListConfiguredAuthenticatorsAsync)
-            .WithOpenApi(o =>
-            {
-                o.Parameters.Get(nameof(ConfiguredAuthenticatorRequest.IsAllowed)).Description = "When 'true', all authenticators on the allowlist are returned. When 'false', all authenticators on the blocklist are returned.";
-                return o;
-            });
+        group.MapGet("/list", ListConfiguredAuthenticatorsAsync);
 
         group.MapPost("/add", AddAuthenticatorsAsync)
             .WithParameterValidation();

--- a/src/Api/Endpoints/Credentials.cs
+++ b/src/Api/Endpoints/Credentials.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Models;
 using Passwordless.Api.OpenApi;
 using Passwordless.Common.Models.Credentials;
 using Passwordless.Service;
 using Passwordless.Service.Helpers;
+using Passwordless.Service.Models;
 using static Microsoft.AspNetCore.Http.Results;
 
 namespace Passwordless.Api.Endpoints;
@@ -30,6 +33,8 @@ public static class CredentialsEndpoints
     /// <summary>
     /// Deletes a credential.
     /// </summary>
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> DeleteCredentialAsync(
         [FromBody] CredentialsDeleteDTO payload,
         [FromServices] UserCredentialsService userCredentialsService)
@@ -42,6 +47,8 @@ public static class CredentialsEndpoints
     /// <summary>
     /// Lists credentials for a given user.
     /// </summary>
+    [ProducesResponseType(typeof(ListResponse<StoredCredential>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static Task<IResult> ListGetCredentialsAsync(
         [AsParameters] GetCredentialsRequest request,
         [FromServices] UserCredentialsService service)
@@ -52,6 +59,8 @@ public static class CredentialsEndpoints
     /// <summary>
     /// Lists credentials for a given user.
     /// </summary>
+    [ProducesResponseType(typeof(ListResponse<StoredCredential>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static Task<IResult> ListPostCredentialsAsync(
         [FromBody] GetCredentialsRequest request,
         [FromServices] UserCredentialsService service)

--- a/src/Api/Endpoints/Events.cs
+++ b/src/Api/Endpoints/Events.cs
@@ -1,4 +1,7 @@
 using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using MiniValidation;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Extensions;
@@ -7,6 +10,7 @@ using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.EventLog.Mappings;
 using Passwordless.Service.EventLog.Models;
 using Passwordless.Service.Features;
+using Passwordless.Service.Models;
 
 namespace Passwordless.Api.Endpoints;
 
@@ -25,6 +29,10 @@ public static class EventLog
     /// Lists event logs. (Requires the `Enterprise` plan.)
     /// </summary>
     /// <returns></returns>
+    [ProducesResponseType(typeof(GetEventLogEventsResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
+    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.Forbidden, MediaTypeNames.Application.ProblemJson)]
+
     private static async Task<IResult> GetEventLogEventsAsync(
         HttpRequest request,
         IEventLogStorage storage,

--- a/src/Api/Endpoints/Magic.cs
+++ b/src/Api/Endpoints/Magic.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Mime;
 using System.Security.Claims;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +11,7 @@ using Passwordless.Service.Features;
 using Passwordless.Service.Helpers;
 using Passwordless.Service.MagicLinks;
 using Passwordless.Service.MagicLinks.Extensions;
+using Passwordless.Service.Models;
 using static Microsoft.AspNetCore.Http.Results;
 
 namespace Passwordless.Api.Endpoints;
@@ -55,6 +58,8 @@ public static class MagicEndpoints
     ///
     /// Warning: Verify the e-mail address matches the user identifier in your backend.
     /// </summary>
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> SendMagicLinkAsync(
         [FromBody] SendMagicLinkRequest request,
         [FromServices] IFeatureContextProvider provider,

--- a/src/Api/Endpoints/Register.cs
+++ b/src/Api/Endpoints/Register.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Net.Mime;
+using Fido2NetLib;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.OpenApi;
@@ -35,6 +38,8 @@ public static class RegisterEndpoints
     /// <summary>
     /// Registration (Step 1 - Server)
     /// </summary>
+    [ProducesResponseType(typeof(RegisterTokenResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> RegisterAsync(
         [FromBody] RegisterToken request,
         [FromServices] IFido2Service fido2Service)
@@ -46,6 +51,8 @@ public static class RegisterEndpoints
     /// <summary>
     /// Registration (Step 2 - Client): Get credential creation options.
     /// </summary>
+    [ProducesResponseType(typeof(SessionResponse<CredentialCreateOptions>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> RegisterBeginAsync(
         [FromBody] FidoRegistrationBeginDTO payload,
         [FromServices] IFido2Service fido2Service)
@@ -57,6 +64,8 @@ public static class RegisterEndpoints
     /// <summary>
     /// Registration (Step 3 - Client): Stores the created public key.
     /// </summary>
+    [ProducesResponseType(typeof(TokenResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> RegisterCompleteAsync(
         [FromBody] RegistrationCompleteDTO payload,
         HttpRequest request,

--- a/src/Api/Endpoints/Reporting.cs
+++ b/src/Api/Endpoints/Reporting.cs
@@ -1,7 +1,11 @@
-﻿using Passwordless.Api.Authorization;
+﻿using System.Net;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+using Passwordless.Api.Authorization;
 using Passwordless.Api.OpenApi;
 using Passwordless.Common.Models.Reporting;
 using Passwordless.Service;
+using Passwordless.Service.Models;
 using static Microsoft.AspNetCore.Http.Results;
 
 namespace Passwordless.Api.Endpoints;
@@ -26,6 +30,8 @@ public static class ReportingEndpoints
     /// <param name="request"></param>
     /// <param name="reportingService"></param>
     /// <returns></returns>
+    [ProducesResponseType(typeof(PeriodicCredentialReportResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> GetPeriodicCredentialReportsAsync(
         [AsParameters] PeriodicCredentialReportRequest request,
         IReportingService reportingService)
@@ -41,6 +47,8 @@ public static class ReportingEndpoints
     /// <param name="request"></param>
     /// <param name="reportingService"></param>
     /// <returns></returns>
+    [ProducesResponseType(typeof(IEnumerable<PeriodicActiveUserReportResponse>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> GetPeriodicActiveUserReportsAsync(
         [AsParameters] PeriodicActiveUserReportRequest request,
         IReportingService reportingService)

--- a/src/Api/Endpoints/Signin.cs
+++ b/src/Api/Endpoints/Signin.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net;
+using System.Net.Mime;
+using Fido2NetLib;
+using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Extensions;
 using Passwordless.Api.OpenApi;
@@ -38,6 +41,8 @@ public static class SigninEndpoints
             .RequireSecretKey(SecretKeyScopes.TokenVerify);
     }
 
+    [ProducesResponseType(typeof(SigninTokenRequest), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> GenerateTokenAsync(
         [FromBody] SigninTokenRequest signinToken,
         [FromServices] IFeatureContextProvider provider,
@@ -57,6 +62,8 @@ public static class SigninEndpoints
     /// <summary>
     /// Signin (Step 1 - Client)
     /// </summary>
+    [ProducesResponseType(typeof(SessionResponse<AssertionOptions>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> BeginAsync(
         [FromBody] SignInBeginDTO payload,
         [FromServices] IFido2Service fido2Service)
@@ -69,6 +76,8 @@ public static class SigninEndpoints
     /// <summary>
     /// Signin (Step 2 - Client)
     /// </summary>
+    [ProducesResponseType(typeof(TokenResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> CompleteAsync(
         [FromBody] SignInCompleteDTO payload,
         HttpRequest request,
@@ -83,6 +92,8 @@ public static class SigninEndpoints
     /// <summary>
     /// Signin (Step 3 - Server)
     /// </summary>
+    [ProducesResponseType(typeof(VerifySignInToken), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> VerifyAsync(
         [FromBody] SignInVerifyDTO payload,
         [FromServices] IFido2Service fido2Service)

--- a/src/Api/Endpoints/Users.cs
+++ b/src/Api/Endpoints/Users.cs
@@ -1,10 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Passwordless.Api.Authorization;
 using Passwordless.Api.Models;
 using Passwordless.Api.OpenApi;
 using Passwordless.Service;
 using Passwordless.Service.EventLog.Loggers;
+using Passwordless.Service.Models;
 using static Microsoft.AspNetCore.Http.Results;
 
 namespace Passwordless.Api.Endpoints;
@@ -29,6 +32,8 @@ public static class UsersEndpoints
     /// <summary>
     /// Get a list of users.
     /// </summary>
+    [ProducesResponseType(typeof(ListResponse<UserSummary>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> GetUsersAsync(
         [FromServices] UserCredentialsService userService)
     {
@@ -40,6 +45,8 @@ public static class UsersEndpoints
     /// <summary>
     /// Get the amount of users.
     /// </summary>
+    [ProducesResponseType(typeof(CountRecord), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> GetUsersCountAsync(
         [FromServices] UserCredentialsService userService)
     {
@@ -51,6 +58,8 @@ public static class UsersEndpoints
     /// <summary>
     /// Deletes a user.
     /// </summary>
+    [ProducesResponseType((int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> DeleteUserAsync(
         [FromBody] UserDeletePayload payload,
         [FromServices] UserCredentialsService userService,

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -183,7 +183,11 @@ else
             "Hey, this place is for computers. Check out our human documentation instead: https://docs.passwordless.dev");
 }
 
-app.UseSwagger();
+app.UseSwagger(c => c.PreSerializeFilters.Add((swaggerDoc, httpReq) =>
+{
+    httpReq.HttpContext.Response.Headers.Append("Access-Control-Allow-Origin", "*");
+}));
+
 app.UseSwaggerUI(c =>
 {
     c.SwaggerEndpoint("/swagger/v4/swagger.json", "v4");

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -14,10 +14,8 @@ using Passwordless.Api.Middleware;
 using Passwordless.Api.OpenApi.Filters;
 using Passwordless.Api.Reporting.Background;
 using Passwordless.Common.Configuration;
-using Passwordless.Common.Extensions;
 using Passwordless.Common.Middleware.SelfHosting;
 using Passwordless.Common.Services.Mail;
-using Passwordless.Common.Utils;
 using Passwordless.Service;
 using Passwordless.Service.EventLog;
 using Passwordless.Service.Features;
@@ -43,7 +41,7 @@ builder.Services.AddSwaggerGen(swagger =>
     });
     swagger.OperationFilter<AuthorizationOperationFilter>();
     swagger.SupportNonNullableReferenceTypes();
-    swagger.SwaggerDoc("v1", new OpenApiInfo
+    swagger.SwaggerDoc("v4", new OpenApiInfo
     {
         Version = "v4",
         Title = "Passwordless.dev API",
@@ -188,10 +186,12 @@ else
 app.UseSwagger();
 app.UseSwaggerUI(c =>
 {
+    c.SwaggerEndpoint("/swagger/v4/swagger.json", "v4");
     c.ConfigObject.ShowExtensions = true;
     c.ConfigObject.ShowCommonExtensions = true;
     c.IndexStream = () => typeof(Program).Assembly.GetManifestResourceStream("Passwordless.Api.OpenApi.swagger.html");
     c.InjectStylesheet("/openapi.css");
+    c.DefaultModelsExpandDepth(-1);
 });
 
 if (builder.Configuration.IsSelfHosted())

--- a/src/Api/wwwroot/openapi.css
+++ b/src/Api/wwwroot/openapi.css
@@ -2,7 +2,7 @@
 
 @font-face {
     font-family: "DM Sans";
-    src: url("DMSans-VariableFont_opsz,wght.ttf") format("truetype");
+    src: url("./DMSans-VariableFont_opsz,wght.ttf") format("truetype");
 }
 
 .swagger-ui html {
@@ -23,7 +23,6 @@
 
 .swagger-ui .opblock-tag {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 .swagger-ui .opblock-tag small {
@@ -32,13 +31,11 @@
 
 .swagger-ui .opblock .opblock-section-header label {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 
 .swagger-ui .opblock .opblock-section-header h4 {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 .swagger-ui .opblock .opblock-summary-method {
@@ -49,8 +46,7 @@
 }
 
 .swagger-ui .opblock .opblock-summary-path, .swagger-ui .opblock .opblock-summary-path__deprecated {
-    font-family: Source Code Pro, monospace;
-    color: #3b4151;
+
 }
 
 .swagger-ui .opblock .opblock-summary-description {
@@ -112,48 +108,18 @@
 
 .swagger-ui .opblock-description-wrapper, .swagger-ui .opblock-description-wrapper h4, .swagger-ui .opblock-title_normal, .swagger-ui .opblock-title_normal h4 {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 .swagger-ui .opblock-description-wrapper p, .swagger-ui .opblock-title_normal p {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 .swagger-ui .responses-inner h4, .swagger-ui .responses-inner h5 {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 .swagger-ui .response-col_status {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
-}
-
-.swagger-ui .response-col_status .response-undocumented {
-    font-family: Source Code Pro, monospace;
-    font-weight: 600;
-    color: #999
-}
-
-.swagger-ui .response-col_description__inner span {
-    background: #41444e;
-    font-family: Source Code Pro, monospace;
-    color: #fff
-}
-
-.swagger-ui .response-col_description__inner span p {
-    margin: 0
-}
-
-.swagger-ui .opblock-body pre {
-    background: #41444e;
-    font-family: Source Code Pro, monospace;
-    color: #fff
-}
-
-.swagger-ui .opblock-body pre span {
-    color: #fff!important
 }
 
 .swagger-ui .scheme-container .schemes>label {
@@ -205,128 +171,24 @@
     }
 }
 
-.swagger-ui .btn-group {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    padding: 30px
-}
-
-.swagger-ui .btn-group .btn {
-    -webkit-box-flex: 1;
-    -ms-flex: 1;
-    flex: 1
-}
-
-.swagger-ui .btn-group .btn:first-child {
-    border-radius: 4px 0 0 4px
-}
-
-.swagger-ui .btn-group .btn:last-child {
-    border-radius: 0 4px 4px 0
-}
-
-.swagger-ui .authorization__btn {
-    padding: 0 10px;
-    border: none;
-    background: none
-}
-
-.swagger-ui .authorization__btn.locked {
-    opacity: 1
-}
-
-.swagger-ui .authorization__btn.unlocked {
-    opacity: .4
-}
-
-.swagger-ui .expand-methods, .swagger-ui .expand-operation {
-    border: none;
-    background: none
-}
-
-.swagger-ui .expand-methods svg, .swagger-ui .expand-operation svg {
-    width: 20px;
-    height: 20px
-}
-
-.swagger-ui .expand-methods {
-    padding: 0 10px
-}
-
-.swagger-ui .expand-methods:hover svg {
-    fill: #444
-}
-
-.swagger-ui .expand-methods svg {
-    -webkit-transition: all .3s;
-    transition: all .3s;
-    fill: #777
-}
-
 .swagger-ui button {
     cursor: pointer;
-    outline: none
 }
 
 .swagger-ui select {
-    font-size: 14px;
-    font-weight: 700;
-    padding: 5px 40px 5px 10px;
-    border: 2px solid #41444e;
-    border-radius: 4px;
-    background: #f7f7f7 url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCI+ICAgIDxwYXRoIGQ9Ik0xMy40MTggNy44NTljLjI3MS0uMjY4LjcwOS0uMjY4Ljk3OCAwIC4yNy4yNjguMjcyLjcwMSAwIC45NjlsLTMuOTA4IDMuODNjLS4yNy4yNjgtLjcwNy4yNjgtLjk3OSAwbC0zLjkwOC0zLjgzYy0uMjctLjI2Ny0uMjctLjcwMSAwLS45NjkuMjcxLS4yNjguNzA5LS4yNjguOTc4IDBMMTAgMTFsMy40MTgtMy4xNDF6Ii8+PC9zdmc+) right 10px center no-repeat;
-    background-size: 20px;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .25);
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none
-}
-
-.swagger-ui select[multiple] {
-    margin: 5px 0;
-    padding: 5px;
-    background: #f7f7f7
-}
-
-.swagger-ui .opblock-body select {
-    min-width: 230px
 }
 
 .swagger-ui label {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
 }
 
-.swagger-ui input[type=email], .swagger-ui input[type=password], .swagger-ui input[type=search], .swagger-ui input[type=text] {
-    border: 1px solid #d9d9d9;
-    background: #fff
-}
-
 .swagger-ui input[type=email].invalid, .swagger-ui input[type=password].invalid, .swagger-ui input[type=search].invalid, .swagger-ui input[type=text].invalid {
     border-color: #ff4e63;
-    background: #feebeb
-}
-
-.swagger-ui textarea {
-    font-family: Source Code Pro, monospace;
 }
 
 .swagger-ui textarea:focus {
     border: 2px solid #175ddc;
-}
-
-.swagger-ui .checkbox {
-    color: #333
-}
-
-.swagger-ui .checkbox p {
-    font-family: Source Code Pro, monospace;
-}
-
-.swagger-ui .checkbox input[type=checkbox]:checked+label>.item {
-    background: #e8e8e8 url("data:image/svg+xml;charset=utf-8,%3Csvg width='10' height='8' viewBox='3 7 10 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%2341474E' fill-rule='evenodd' d='M6.333 15L3 11.667l1.333-1.334 2 2L11.667 7 13 8.333z'/%3E%3C/svg%3E") 50% no-repeat
 }
 
 .swagger-ui .dialog-ux .modal-ux-content p {
@@ -341,175 +203,36 @@
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
 }
 
-.swagger-ui .model {
-    font-family: Source Code Pro, monospace;
-}
-
-.swagger-ui .model-toggle:after {
-    display: block;
-    width: 20px;
-    height: 20px;
-    content: "";
-    background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z'/%3E%3C/svg%3E") 50% no-repeat;
-    background-size: 100%
-}
-
-.swagger-ui .model-hint {
-    color: #ebebeb;
-    background: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui section.models {
-    border: 1px solid rgba(59, 65, 81, .3);
-}
-
-.swagger-ui section.models.is-open h4 {
-    border-bottom: 1px solid rgba(59, 65, 81, .3)
-}
-
 .swagger-ui section.models h4 {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #777;
-}
-
-.swagger-ui section.models h4:hover {
-    background: rgba(0, 0, 0, .02)
 }
 
 .swagger-ui section.models h5 {
-    font-size: 16px;
-    margin: 0 0 10px;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #777
-}
-
-.swagger-ui section.models .model-jump-to-path {
-    position: relative;
-    top: 5px
-}
-
-.swagger-ui section.models .model-container {
-    margin: 0 20px 15px;
-    -webkit-transition: all .5s;
-    transition: all .5s;
-    border-radius: 4px;
-    background: rgba(0, 0, 0, .05)
-}
-
-.swagger-ui section.models .model-container:hover {
-    background: rgba(0, 0, 0, .07)
-}
-
-.swagger-ui section.models .model-container:first-of-type {
-    margin: 20px
-}
-
-.swagger-ui section.models .model-container:last-of-type {
-    margin: 0 20px
-}
-
-.swagger-ui section.models .model-box {
-    background: none
-}
-
-.swagger-ui .model-box {
-    padding: 10px;
-    border-radius: 4px;
-    background: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .model-box .model-jump-to-path {
-    position: relative;
-    top: 4px
 }
 
 .swagger-ui .model-title {
-    font-size: 16px;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #555
-}
-
-.swagger-ui span>span.model, .swagger-ui span>span.model .brace-close {
-    padding: 0 0 0 10px
 }
 
 .swagger-ui .prop-type {
     color: #1A41AC;
 }
 
-.swagger-ui .prop-enum {
-    display: block
-}
-
 .swagger-ui .prop-format {
     color: #999
 }
 
-.swagger-ui table {
-    width: 100%;
-    padding: 0 10px;
-    border-collapse: collapse
-}
-
-.swagger-ui table.model tbody tr td {
-    padding: 0;
-    vertical-align: top
-}
-
-.swagger-ui table.model tbody tr td:first-of-type {
-    width: 100px;
-    padding: 0
-}
-
-.swagger-ui table.headers td {
-    font-size: 12px;
-    vertical-align: middle;
-    font-family: Source Code Pro, monospace;
-    font-weight: 600;
-    color: #3b4151
-}
-
-.swagger-ui table tbody tr td {
-    padding: 10px 0 0;
-    vertical-align: top
-}
-
-.swagger-ui table tbody tr td:first-of-type {
-    width: 20%;
-    padding: 10px 0
-}
-
 .swagger-ui table thead tr td, .swagger-ui table thead tr th {
-    font-size: 12px;
-    font-weight: 700;
-    padding: 12px 0;
-    text-align: left;
-    border-bottom: 1px solid rgba(59, 65, 81, .2);
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
 }
 
 .swagger-ui .parameters-col_description p {
-    font-size: 14px;
-    margin: 0;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
-}
-
-.swagger-ui .parameters-col_description input[type=text] {
-    width: 100%;
-    max-width: 340px
 }
 
 .swagger-ui .parameter__name {
-    font-size: 16px;
-    font-weight: 400;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
-}
-
-.swagger-ui .parameter__name.required {
-    font-weight: 700
 }
 
 .swagger-ui .parameter__name.required span {
@@ -522,56 +245,24 @@
 }
 
 .swagger-ui .parameter__in {
-    font-family: Source Code Pro, monospace;
     color: #888
 }
 
 .swagger-ui .topbar a {
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #fff
 }
 
 .swagger-ui .topbar .download-url-wrapper input[type=text] {
-    min-width: 350px;
-    margin: 0;
     border: 2px solid #175ddc;
-    border-radius: 4px 0 0 4px;
-    outline: none
 }
 
 .swagger-ui .topbar .download-url-wrapper .download-url-button {
-    border: none;
-    border-radius: 0 4px 4px 0;
     background: #175ddc;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #fff
-}
-
-.swagger-ui .info {
-    margin: 50px 0
-}
-
-.swagger-ui .info hgroup.main {
-    margin: 0 0 20px
-}
-
-.swagger-ui .info hgroup.main a {
-    font-size: 12px
 }
 
 .swagger-ui .info p {
-    font-size: 14px;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
-}
-
-.swagger-ui .info code {
-    padding: 3px 5px;
-    border-radius: 4px;
-    background: rgba(0, 0, 0, .05);
-    font-family: Source Code Pro, monospace;
-    font-weight: 600;
-    color: #9012fe
 }
 
 .swagger-ui .info a {
@@ -583,16 +274,8 @@
     color: #175ddc;
 }
 
-.swagger-ui .info>div {
+.swagger-ui .info > div {
     margin: 0;
-}
-
-.swagger-ui .info .base-url {
-    font-size: 12px;
-    font-weight: 300 !important;
-    margin: 0;
-    font-family: Source Code Pro, monospace;
-    color: #3b4151
 }
 
 .swagger-ui .info .title {
@@ -600,36 +283,11 @@
 }
 
 .swagger-ui .info .title small pre {
-    margin: 0;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #fff
-}
-
-.swagger-ui .auth-container {
-    border-bottom: 1px solid #ebebeb
-}
-
-.swagger-ui .auth-container:last-of-type {
-    border: 0
-}
-
-.swagger-ui .auth-container .errors {
-    font-size: 12px;
-    padding: 10px;
-    border-radius: 4px;
-    font-family: Source Code Pro, monospace;
-    font-weight: 600;
-    color: #3b4151
 }
 
 .swagger-ui .scopes h2 {
-    font-size: 14px;
     font-family: DM Sans,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica Neue,sans-serif;
-    color: #3b4151
-}
-
-.swagger-ui .scope-def {
-    padding: 0 0 20px
 }
 
 .swagger-ui .errors-wrapper {
@@ -640,18 +298,6 @@
     border: 2px solid #ff4e63;
     border-radius: 4px;
     background: rgba(249, 62, 62, .1)
-}
-
-.swagger-ui .errors-wrapper .error-wrapper {
-    margin: 0 0 10px
-}
-
-.swagger-ui .errors-wrapper .errors h4 {
-    font-size: 14px;
-    margin: 0;
-    font-family: Source Code Pro, monospace;
-    font-weight: 600;
-    color: #3b4151
 }
 
 .swagger-ui .errors-wrapper hgroup h4 {

--- a/src/Api/wwwroot/openapi.css
+++ b/src/Api/wwwroot/openapi.css
@@ -325,3 +325,11 @@ img[alt="Swagger UI"] {
     max-width: 100%;
     max-height: 100%;
 }
+
+th, td {
+    border: none;
+}
+
+tr {
+    border-top: none;
+}

--- a/src/Common/Models/Authenticators/ConfiguredAuthenticatorRequest.cs
+++ b/src/Common/Models/Authenticators/ConfiguredAuthenticatorRequest.cs
@@ -3,5 +3,5 @@ namespace Passwordless.Common.Models.Authenticators;
 /// <summary>
 /// 
 /// </summary>
-/// <param name="IsAllowed">Whether or not an authenticator is whitelisted or blacklisted.</param>
+/// <param name="IsAllowed">When 'true', all authenticators on the allowlist are returned. When 'false', all authenticators on the blocklist are returned.</param>
 public record ConfiguredAuthenticatorRequest(bool IsAllowed);


### PR DESCRIPTION
### Ticket
- Closes [PAS-202](https://bitwarden.atlassian.net/browse/PAS-202)

### Description

- Add response types for every endpoint
- Remove list of schemas at the bottom, which is now completely redundant given they're present on the endpoints themselves.
- Rename schema definition from v1 to v4.
- Apply CORS policy to the schema at /swagger/v4/swagger.json so we can use the schema with VuePress.
- Fix where `GET /authenticators/list` applies many ApiSecret headers to the schema.
- CSS cleanup

### Shape

n/a

### Screenshots

<img width="1436" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/e2ff9ea7-aba2-4672-ba92-1c40bf727f5e">

<img width="1436" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/a13159af-a17a-455d-8d67-9e43ae9012bf">

<img width="1436" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/67a44c92-31f2-45cb-be6f-e3be8ef66ab0">

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __

[PAS-202]: https://bitwarden.atlassian.net/browse/PAS-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ