### PR TITLE
Change verbosity of wrong ApiKey logging.

### DIFF
--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -178,7 +178,7 @@ public class SharedManagementService : ISharedManagementService
         }
 
         _eventLogger.LogInvalidPublicKeyUsedEvent(_systemClock.UtcNow.UtcDateTime, appId, new ApplicationPublicKey(publicKey));
-        _logger.LogWarning("Apikey was not valid. {AppId} {ApiKey}", appId, publicKey);
+        _logger.LogInformation("Apikey was not valid. {AppId} {ApiKey}", appId, publicKey);
         throw new ApiException("Apikey was not valid", 401);
     }
 


### PR DESCRIPTION
### Description

Datadog got spammed by too many wrong ApiKey entries with logging level warning. In all the noise we might miss important information.

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
