### PR TITLE
PAS-406 | Check authenticators exist in MDS before configuration

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/Authenticators.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/Authenticators.razor
@@ -60,7 +60,7 @@
         Allowlist = allowlist
             .Select(x => new ConfiguredAuthenticatorViewModel(
                 x.AaGuid,
-                mds.First(m => m.AaGuid == x.AaGuid).Name))
+                mds.FirstOrDefault(m => m.AaGuid == x.AaGuid)?.Name ?? "Authenticator"))
             .OrderBy(x => x.Name)
             .ToList();
         _isInitialized = true;

--- a/src/Api/Endpoints/Users.cs
+++ b/src/Api/Endpoints/Users.cs
@@ -58,7 +58,7 @@ public static class UsersEndpoints
     /// <summary>
     /// Deletes a user.
     /// </summary>
-    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType((int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> DeleteUserAsync(
         [FromBody] UserDeletePayload payload,
@@ -69,7 +69,7 @@ public static class UsersEndpoints
 
         eventLogger.LogDeletedUserEvent(payload.UserId);
 
-        return NoContent();
+        return Ok();
     }
 
     public record CountRecord(int Count);

--- a/src/Api/Endpoints/Users.cs
+++ b/src/Api/Endpoints/Users.cs
@@ -58,7 +58,7 @@ public static class UsersEndpoints
     /// <summary>
     /// Deletes a user.
     /// </summary>
-    [ProducesResponseType((int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> DeleteUserAsync(
         [FromBody] UserDeletePayload payload,
@@ -69,7 +69,7 @@ public static class UsersEndpoints
 
         eventLogger.LogDeletedUserEvent(payload.UserId);
 
-        return Ok();
+        return NoContent();
     }
 
     public record CountRecord(int Count);

--- a/src/Common/Models/Authenticators/AddAuthenticatorsRequest.cs
+++ b/src/Common/Models/Authenticators/AddAuthenticatorsRequest.cs
@@ -4,6 +4,6 @@ namespace Passwordless.Common.Models.Authenticators;
 
 public record AddAuthenticatorsRequest(
     [Required, MinLength(1)]
-    IEnumerable<Guid> AaGuids,
+    IReadOnlyCollection<Guid> AaGuids,
 
     bool IsAllowed);

--- a/src/Service/ApplicationService.cs
+++ b/src/Service/ApplicationService.cs
@@ -2,6 +2,7 @@ using Passwordless.Common.Models.Apps;
 using Passwordless.Common.Models.Authenticators;
 using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.Helpers;
+using Passwordless.Service.MDS;
 using Passwordless.Service.Storage.Ef;
 
 namespace Passwordless.Service;
@@ -10,11 +11,16 @@ public class ApplicationService : IApplicationService
 {
     private readonly ITenantStorage _storage;
     private readonly IEventLogger _eventLogger;
+    private readonly IMetaDataService _metaDataService;
 
-    public ApplicationService(ITenantStorage storage, IEventLogger eventLogger)
+    public ApplicationService(
+        ITenantStorage storage,
+        IEventLogger eventLogger,
+        IMetaDataService metaDataService)
     {
         _storage = storage;
         _eventLogger = eventLogger;
+        _metaDataService = metaDataService;
     }
 
     public async Task SetFeaturesAsync(SetFeaturesRequest features)
@@ -40,9 +46,14 @@ public class ApplicationService : IApplicationService
         return entities.Select(x => new ConfiguredAuthenticatorResponse(x.AaGuid, x.CreatedAt)).ToList();
     }
 
-    public Task AddAuthenticatorsAsync(AddAuthenticatorsRequest request)
+    public async Task AddAuthenticatorsAsync(AddAuthenticatorsRequest request)
     {
-        return _storage.AddAuthenticatorsAsync(request.AaGuids, request.IsAllowed);
+        if (!(await _metaDataService.IsExistsAsync(request.AaGuids)))
+        {
+            throw new ApiException("One or more authenticators do not exist in the FIDO2 MDS.", 400);
+        }
+
+        await _storage.AddAuthenticatorsAsync(request.AaGuids, request.IsAllowed);
     }
 
     public Task RemoveAuthenticatorsAsync(RemoveAuthenticatorsRequest request)

--- a/src/Service/MDS/IMetaDataService.cs
+++ b/src/Service/MDS/IMetaDataService.cs
@@ -7,4 +7,11 @@ public interface IMetaDataService
     Task<IEnumerable<string>> GetAttestationTypesAsync();
     Task<IEnumerable<EntryResponse>> GetEntriesAsync(EntriesRequest request);
     Task<IEnumerable<string>> GetCertificationStatusesAsync();
+
+    /// <summary>
+    /// Checks whether all the given authenticators exist in the FIDO2 MDS.
+    /// </summary>
+    /// <param name="aaGuids"></param>
+    /// <returns>Returns `true` if all the authenticators exist in the FIDO2 MDS; otherwise, `false`.</returns>
+    Task<bool> IsExistsAsync(IReadOnlyCollection<Guid> aaGuids);
 }

--- a/src/Service/MDS/MetaDataService.cs
+++ b/src/Service/MDS/MetaDataService.cs
@@ -76,4 +76,13 @@ public sealed class MetaDataService : DistributedCacheMetadataService, IMetaData
             .ToList();
         return result;
     }
+
+    public async Task<bool> IsExistsAsync(IReadOnlyCollection<Guid> aaGuids)
+    {
+        var blob = await GetDistributedCachedBlob(base._repositories.First());
+        var result = blob.Entries
+            .Count(x => x.MetadataStatement.ProtocolFamily == "fido2" &&
+                        aaGuids.Contains(x.AaGuid!.Value));
+        return result == aaGuids.Count;
+    }
 }

--- a/tests/Service.Tests/Implementations/ApplicationServiceTests.cs
+++ b/tests/Service.Tests/Implementations/ApplicationServiceTests.cs
@@ -1,7 +1,9 @@
 using Moq;
 using Passwordless.Common.Models.Apps;
+using Passwordless.Common.Models.Authenticators;
 using Passwordless.Service.EventLog.Loggers;
 using Passwordless.Service.Helpers;
+using Passwordless.Service.MDS;
 using Passwordless.Service.Storage.Ef;
 
 namespace Passwordless.Service.Tests.Implementations;
@@ -10,12 +12,13 @@ public class ApplicationServiceTests
 {
     private readonly Mock<ITenantStorage> _storageMock = new();
     private readonly Mock<IEventLogger> _eventLoggerMock = new();
+    private readonly Mock<IMetaDataService> _metaDataServiceMock = new();
 
     private readonly ApplicationService _sut;
 
     public ApplicationServiceTests()
     {
-        _sut = new ApplicationService(_storageMock.Object, _eventLoggerMock.Object);
+        _sut = new ApplicationService(_storageMock.Object, _eventLoggerMock.Object, _metaDataServiceMock.Object);
     }
 
     #region SetFeaturesAsync
@@ -42,6 +45,67 @@ public class ApplicationServiceTests
 
         _storageMock.Verify(x => x.SetFeaturesAsync(
             It.Is<SetFeaturesRequest>(p => p == payload)), Times.Once);
+    }
+    #endregion
+
+    #region AddAuthenticatorsAsync
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AddAuthenticatorsAsync_Throws_ApiException_WhenAuthenticatorDoesNotExist(bool isAllowed)
+    {
+        // Arrange
+        var payload = new AddAuthenticatorsRequest(new List<Guid> { Guid.NewGuid() }, isAllowed);
+
+        _metaDataServiceMock.Setup(x =>
+                x.IsExistsAsync(
+                    It.Is<IReadOnlyCollection<Guid>>(p => p == payload.AaGuids)))
+            .ReturnsAsync(false);
+
+        // Act
+        var actual = await Assert.ThrowsAsync<ApiException>(async () => await _sut.AddAuthenticatorsAsync(payload));
+
+        // Assert
+        Assert.Equal(400, actual.StatusCode);
+        Assert.Equal("One or more authenticators do not exist in the FIDO2 MDS.", actual.Message);
+
+        _metaDataServiceMock.Verify(x =>
+                x.IsExistsAsync(
+                    It.Is<IReadOnlyCollection<Guid>>(p => p == payload.AaGuids)),
+            Times.Once);
+
+        _storageMock.Verify(x =>
+            x.AddAuthenticatorsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(),
+                It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AddAuthenticatorsAsync_Returns_ExpectedResult()
+    {
+        // Arrange
+        var payload = new AddAuthenticatorsRequest(new List<Guid> { Guid.NewGuid() }, true);
+
+        _metaDataServiceMock.Setup(x =>
+                x.IsExistsAsync(
+                    It.Is<IReadOnlyCollection<Guid>>(p => p == payload.AaGuids)))
+            .ReturnsAsync(true);
+
+        // Act
+        await _sut.AddAuthenticatorsAsync(payload);
+
+        // Assert
+        _metaDataServiceMock.Verify(x =>
+                x.IsExistsAsync(
+                    It.Is<IReadOnlyCollection<Guid>>(p => p == payload.AaGuids)),
+            Times.Once);
+
+        _storageMock.Verify(x =>
+            x.AddAuthenticatorsAsync(
+                It.Is<IReadOnlyCollection<Guid>>(p => p == payload.AaGuids),
+                It.Is<bool>(p => p == payload.IsAllowed)),
+            Times.Once);
     }
     #endregion
 }


### PR DESCRIPTION
### Ticket
- Closes [PAS-406](https://bitwarden.atlassian.net/browse/PAS-406)

### Description

- Check if authenticator exists in MDS before configuration
- Show default label 'Authenticator' in admin console when a configured authenticator is removed in MDS since we do not own the data.

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
