### PR TITLE
PAS-202 | Add missing description for generating an authentication token

### DIFF
--- a/src/Api/Endpoints/Signin.cs
+++ b/src/Api/Endpoints/Signin.cs
@@ -41,6 +41,10 @@ public static class SigninEndpoints
             .RequireSecretKey(SecretKeyScopes.TokenVerify);
     }
 
+    /// <summary>
+    /// Manually generates an authentication token for the specified user, side-stepping the usual authentication flow.
+    /// This approach can be used to implement a "magic link"-style login and other similar scenarios.
+    /// </summary>
     [ProducesResponseType(typeof(SigninTokenRequest), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest, MediaTypeNames.Application.ProblemJson)]
     public static async Task<IResult> GenerateTokenAsync(


### PR DESCRIPTION
### Ticket
- Closes [PAS-202](https://bitwarden.atlassian.net/browse/PAS-202)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

Copied from Passwordless .NET SDK

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-202]: https://bitwarden.atlassian.net/browse/PAS-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ