### PR TITLE
Fix navigation on /Organization/Overview

### DIFF
--- a/src/AdminConsole/Pages/Organization/Overview.cshtml
+++ b/src/AdminConsole/Pages/Organization/Overview.cshtml
@@ -10,7 +10,7 @@
     @foreach (var app in Model.Org.Applications)
     {
         <li>
-            <a asp-page="@Model.GetApplicationUrl(app)" asp-route-appId="@app.Id" class="block hover:bg-gray-50">
+            <a href="@Model.GetApplicationUrl(app)" class="block hover:bg-gray-50">
                 <div class="flex items-center px-4 py-4 sm:px-6">
                 <div class="flex min-w-0 flex-1 items-center">
                     <div class="min-w-0 flex-1 px-4 md:grid md:grid-cols-2 md:gap-4">

--- a/src/AdminConsole/Pages/Organization/Overview.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/Overview.cshtml.cs
@@ -38,7 +38,7 @@ public class OverviewModel : PageModel
     public string GetApplicationUrl(Models.Application application)
     {
         string url = application.DeleteAt.HasValue
-            ? "/app/Settings/Settings"
+            ? $"/app/{application.Id}/Settings"
             : $"/app/{application.Id}/credentials/list";
         return url;
     }

--- a/src/AdminConsole/Pages/Organization/Overview.cshtml.cs
+++ b/src/AdminConsole/Pages/Organization/Overview.cshtml.cs
@@ -39,7 +39,7 @@ public class OverviewModel : PageModel
     {
         string url = application.DeleteAt.HasValue
             ? "/app/Settings/Settings"
-            : "/app/credentials/list";
+            : $"/app/{application.Id}/credentials/list";
         return url;
     }
 }


### PR DESCRIPTION
### Description

The navigation is broken clicking one of the application cards. That is because the credentials list is not a Razor Page.

### Shape

n/a

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
