### PR TITLE
PAS-412 & PAS-413 | Disable enhanced navigation globally

### DIFF
--- a/src/AdminConsole/Components/App.razor
+++ b/src/AdminConsole/Components/App.razor
@@ -12,7 +12,12 @@
 
 <body class="h-full bg-gray-50">
     <Routes/>
-    <script src="_framework/blazor.web.js"></script>
+    <script src="_framework/blazor.web.js" autostart="false"></script>
     <SecureScript type="text/javascript" src="js/core.js" />
+    <SecureScript>
+        Blazor.start({
+        ssr: { disableDomPreservation: true }
+        });
+    </SecureScript>
 </body>
 </html>


### PR DESCRIPTION
### Ticket
- Closes [PAS-412](https://bitwarden.atlassian.net/browse/PAS-412)
- Closes [PAS-413](https://bitwarden.atlassian.net/browse/PAS-413)

### Description

Some elements to not seem to be initialized properly when the page loads, this is caused by Blazor's enhanced navigation feature which is enabled by default.

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-412]: https://bitwarden.atlassian.net/browse/PAS-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAS-413]: https://bitwarden.atlassian.net/browse/PAS-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ