### PR TITLE
string interning for health check endpoints

### DIFF
--- a/src/AdminConsole/HealthChecks/HealthCheckBootstrap.cs
+++ b/src/AdminConsole/HealthChecks/HealthCheckBootstrap.cs
@@ -39,21 +39,23 @@ public static class HealthCheckBootstrap
 
     public static void MapPasswordlessHealthChecks(this WebApplication app)
     {
-        app.MapHealthChecks("/health/http", new HealthCheckOptions
+        var group = app.MapGroup(HealthCheckEndpoints.Path);
+
+        group.MapHealthChecks("/http", new HealthCheckOptions
         {
             Predicate = registration => registration.Tags.Contains(TagSimple)
         });
-        app.MapHealthChecks("/health/storage", new HealthCheckOptions
+        group.MapHealthChecks("/storage", new HealthCheckOptions
         {
             ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
             Predicate = registration => registration.Tags.Contains(TagDatabase)
         });
-        app.MapHealthChecks("/health/version", new HealthCheckOptions
+        group.MapHealthChecks("/version", new HealthCheckOptions
         {
             ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
             Predicate = registration => registration.Tags.Contains(TagVersion)
         });
-        app.MapHealthChecks("/health/mail", new HealthCheckOptions
+        group.MapHealthChecks("/mail", new HealthCheckOptions
         {
             ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
             Predicate = registration => registration.Tags.Contains(TagMail)

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -20,6 +20,7 @@ using Passwordless.AdminConsole.Services.Mail;
 using Passwordless.AdminConsole.Services.PasswordlessManagement;
 using Passwordless.AspNetCore;
 using Passwordless.Common.Configuration;
+using Passwordless.Common.HealthChecks;
 using Passwordless.Common.Middleware.SelfHosting;
 using Passwordless.Common.Services.Mail;
 using Serilog;
@@ -199,7 +200,7 @@ void RunTheApp()
     app.UseRouting();
     app.UseAuthentication();
     app.UseWhen(
-        context => !context.Request.Path.StartsWithSegments("/health"),
+        context => !context.Request.Path.StartsWithSegments(HealthCheckEndpoints.Path),
         appBuilder =>
         {
             appBuilder.UseMiddleware<CurrentContextMiddleware>();

--- a/src/Api/HealthChecks/HealthCheckBootstrap.cs
+++ b/src/Api/HealthChecks/HealthCheckBootstrap.cs
@@ -38,21 +38,22 @@ public static class HealthCheckBootstrap
 
     public static void MapPasswordlessHealthChecks(this WebApplication app)
     {
-        app.MapHealthChecks("/health/http", new HealthCheckOptions
+        var group = app.MapGroup(HealthCheckEndpoints.Path);
+        group.MapHealthChecks("/health/http", new HealthCheckOptions
         {
             Predicate = registration => registration.Tags.Contains(TagSimple)
         });
-        app.MapHealthChecks("/health/storage", new HealthCheckOptions
+        group.MapHealthChecks("/health/storage", new HealthCheckOptions
         {
             ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
             Predicate = registration => registration.Tags.Contains(TagDatabase)
         });
-        app.MapHealthChecks("/health/version", new HealthCheckOptions
+        group.MapHealthChecks("/health/version", new HealthCheckOptions
         {
             ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
             Predicate = registration => registration.Tags.Contains(TagVersion)
         });
-        app.MapHealthChecks("/health/mail", new HealthCheckOptions
+        group.MapHealthChecks("/health/mail", new HealthCheckOptions
         {
             ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
             Predicate = registration => registration.Tags.Contains(TagMail)

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -15,6 +15,7 @@ using Passwordless.Api.OpenApi.Filters;
 using Passwordless.Api.RateLimiting;
 using Passwordless.Api.Reporting.Background;
 using Passwordless.Common.Configuration;
+using Passwordless.Common.HealthChecks;
 using Passwordless.Common.Middleware.SelfHosting;
 using Passwordless.Common.Services.Mail;
 using Passwordless.Service;
@@ -215,7 +216,7 @@ app.UseWhen(o =>
     {
         return false;
     }
-    return !o.Request.Path.StartsWithSegments("/health");
+    return !o.Request.Path.StartsWithSegments(HealthCheckEndpoints.Path);
 }, c =>
 {
     c.UseMiddleware<EventLogStorageCommitMiddleware>();
@@ -231,7 +232,7 @@ app.UseWhen(o =>
     {
         return false;
     }
-    return !o.Request.Path.StartsWithSegments("/health");
+    return !o.Request.Path.StartsWithSegments(HealthCheckEndpoints.Path);
 }, c =>
 {
     c.UseMiddleware<EventLogContextMiddleware>();

--- a/src/Common/HealthChecks/HealthCheckEndpoints.cs
+++ b/src/Common/HealthChecks/HealthCheckEndpoints.cs
@@ -1,0 +1,6 @@
+namespace Passwordless.Common.HealthChecks;
+
+public static class HealthCheckEndpoints
+{
+    public const string Path = "/health";
+}


### PR DESCRIPTION
### Description

Using constants for health check endpoints

### Shape

Allows the strings to be interned and allocated once in memory. Should improve memory allocation for middleware operations.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
