### PR TITLE
Make the magic link timeout for newly created accounts configurable

### DIFF
--- a/src/Service/MagicLinks/MagicLinkService.cs
+++ b/src/Service/MagicLinks/MagicLinkService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Passwordless.Common.MagicLinks.Models;
 using Passwordless.Common.Services.Mail;
 using Passwordless.Service.EventLog.Loggers;
@@ -9,25 +10,30 @@ namespace Passwordless.Service.MagicLinks;
 
 public class MagicLinkService(
     TimeProvider timeProvider,
+    IConfiguration configuration,
     ITenantStorage tenantStorage,
     IFido2Service fido2Service,
     IMailProvider mailProvider,
     IEventLogger eventLogger)
 {
+    private TimeSpan NewAccountTimeout { get; } =
+        configuration.GetSection("MagicLinks").GetValue<TimeSpan?>(nameof(NewAccountTimeout)) ??
+        TimeSpan.FromHours(24);
+
     private async Task EnforceQuotaAsync(MagicLinkTokenRequest request)
     {
-        var now = timeProvider.GetUtcNow();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
         var account = await tenantStorage.GetAccountInformation();
         var accountAge = now - account.CreatedAt;
 
-        // Applications created less than 24 hours ago can only send magic links to the admin email address
-        if (accountAge < TimeSpan.FromHours(24) &&
+        // Newly created accounts can only send magic links to the admin email address
+        if (accountAge < NewAccountTimeout &&
             !IsAdminConsole(account) &&
             !account.AdminEmails.Contains(request.EmailAddress.Address, StringComparer.OrdinalIgnoreCase))
         {
             throw new ApiException(
                 "magic_link_email_admin_address_only",
-                "Because your application has been created less than 24 hours ago, " +
+                $"Because your application has been created less than {(int)NewAccountTimeout.TotalHours} hours ago, " +
                 "you can only request magic links to the admin email address.",
                 403
             );
@@ -51,7 +57,6 @@ public class MagicLinkService(
         var quota = (int)(maxQuota * quotaModifier);
 
         var emailsDispatchedIn30Days = await tenantStorage.GetDispatchedEmailCountAsync(TimeSpan.FromDays(30));
-
         if (emailsDispatchedIn30Days >= quota)
         {
             throw new ApiException(
@@ -80,7 +85,7 @@ public class MagicLinkService(
             Subject = $"Sign in to {link.Host}",
             TextBody = $"Please click the link or copy into your browser of choice to log in to {link.Host}: {link}. If you did not request this email, it is safe to ignore.",
             HtmlBody =
-                //lang=html
+                // lang=html
                 $"""
                  <!DOCTYPE html5>
                  <html lang="en">

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -182,6 +182,39 @@ public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture api
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
+    [Fact]
+    public async Task I_can_send_a_magic_link_email_to_a_non_admin_address_if_the_application_is_old_enough()
+    {
+        // Arrange
+        await using var api = await apiFixture.CreateApiAsync(new PasswordlessApiOptions
+        {
+            TestOutput = testOutput,
+            Settings = new Dictionary<string, string?>
+            {
+                // 1 day 13 hours = 37 hours
+                ["MagicLinks:NewAccountTimeout"] = "1.13:00:00"
+            }
+        });
+
+        using var client = api.CreateClient();
+
+        var applicationName = CreateAppHelpers.GetApplicationName();
+        using var appCreateResponse =
+            await client.CreateApplicationAsync(applicationName, new CreateAppDto { AdminEmail = "admin@email.com" });
+        var appCreated = await appCreateResponse.Content.ReadFromJsonAsync<CreateAppResultDto>();
+        client.AddSecretKey(appCreated!.ApiSecret1);
+        await client.EnableMagicLinks("a_user");
+        var request = _requestFaker.Generate();
+
+        api.Time.Advance(TimeSpan.FromHours(37.1));
+
+        // Act
+        using var response = await client.PostAsJsonAsync("magic-links/send", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
     // Test assumes that the quota will eventually be exhausted.
     // Timeout is used as fallback in case that assumption fails.
     [Fact(Timeout = 60_000)]


### PR DESCRIPTION
Configuration option: `MagicLinks.NewAccountTimeout`. uses the standard .NET `TimeSpan` format, e.g. `17:00:00` (17 hours) or `1.16:00:00` (1 day and 16 hours). Defaults to 24 hours if not set.