### PR TITLE
PAS-418 | Fix bullet points showing up for lists where it's not supposed to.

### DIFF
--- a/src/AdminConsole/Styles/tailwind.css
+++ b/src/AdminConsole/Styles/tailwind.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 @layer components {
-    ul {
+    ul.validation-errors {
         @apply list-disc ml-4;
     }
     


### PR DESCRIPTION
### Ticket
- Closes [PAS-418](https://bitwarden.atlassian.net/browse/PAS-418)


### Description

I had overwritten the default style for lists. Which didn't have discs by default, instead had 'none'. This reverts the change and only applies the bullet points to the validation-errors.

### Shape

n/a

### Screenshots

<img width="1782" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/2d7b9b11-3da2-43ce-8df2-452f46c05fa2">

<img width="1782" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/c4938196-4318-4925-925d-7b7c398ef73f">

<img width="1782" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/5ab28f18-6d42-4aa2-9449-329e5011c6cd">

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-418]: https://bitwarden.atlassian.net/browse/PAS-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ