### PR TITLE
PAS-419 | < .NET 8.0.203 don't support NavigationManager.Refresh()

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.101",
-    "rollForward": "latestFeature"
+    "version": "8.0.203",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-419](https://bitwarden.atlassian.net/browse/PAS-419)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

In .NET 8.0.2 and lower, `NavigationManager.Refresh()` was not working properly for Blazor applications that are statically rendered. This is fixed in `8.0.203` and higher.

It is important to avoid touching the rule below in`.editorconfig` as otherwise `dotnet format` would be broken.
`dotnet_diagnostic.IDE0005.severity = silent`

### Shape

n/a

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-419]: https://bitwarden.atlassian.net/browse/PAS-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ