### PR TITLE
PAS-419 | Provide backwards compatibility for .NET 8.0.1 runtime and lower

### DIFF
--- a/src/AdminConsole/Components/Pages/Organization/Admins.razor.cs
+++ b/src/AdminConsole/Components/Pages/Organization/Admins.razor.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Passwordless.AdminConsole.Components.Shared;
 using Passwordless.AdminConsole.EventLog.Loggers;
 using Passwordless.AdminConsole.Helpers;
 using Passwordless.AdminConsole.Identity;
@@ -93,7 +94,7 @@ public partial class Admins : ComponentBase
             NavigationManager.NavigateTo("/Account/Login");
         }
 
-        NavigationManager.Refresh();
+        NavigationManager.RefreshCompat();
     }
 
     private async Task OnValidInviteAsync()
@@ -132,7 +133,7 @@ public partial class Admins : ComponentBase
         await InvitationService.SendInviteAsync(InviteForm.Email!, CurrentContext.Organization!.Id, CurrentContext.Organization!.Name, user.Email!, user.Name);
         EventLogger.LogInviteAdminEvent(user, InviteForm.Email!, TimeProvider.GetUtcNow().UtcDateTime);
 
-        NavigationManager.Refresh();
+        NavigationManager.RefreshCompat();
     }
 
     public async Task CancelInviteAsync()
@@ -153,7 +154,7 @@ public partial class Admins : ComponentBase
 
         EventLogger.LogCancelAdminInviteEvent(performedBy, invite.ToEmail, TimeProvider.GetUtcNow().UtcDateTime);
 
-        NavigationManager.Refresh();
+        NavigationManager.RefreshCompat();
     }
 
     public class DeleteActiveFormModel

--- a/src/AdminConsole/Components/Shared/NavigationManagerExtensions.cs
+++ b/src/AdminConsole/Components/Shared/NavigationManagerExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Passwordless.AdminConsole.Components.Shared;
+
+public static class NavigationManagerExtensions
+{
+    /// <summary>
+    /// Refreshes the current page. Required for .NET 8.0.1 runtime and below.
+    /// </summary>
+    /// <param name="navigationManager"></param>
+    public static void RefreshCompat(this NavigationManager navigationManager)
+    {
+        navigationManager.NavigateTo(navigationManager.Uri, forceLoad: true);
+    }
+}


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-419](https://bitwarden.atlassian.net/browse/PAS-419)

### Description

A .NET runtime bug with relation to `NavigationManager.Refresh()` is causing the `Admins` page to crash under certain circumstances when refreshing the page.

After investigation, I found that the .NET runtime in 'QA', 'Staging' and 'Production is using `.NET Runtime 8.0.101`.

Until Microsoft upgrades the runtimes of Azure Web Applications in Azure, this pull request provides backwards compatibility.

Update (April 15, 2024): Received response from Microsoft `Following discussions with our internal team about the availability of the latest .NET8 SDK and runtime for your app services, I'd like to inform you that the deployment to update to the latest .NET8 SDK and runtime is scheduled to begin in May and will be completed by the end of May 2024.`

### Shape

- https://github.com/dotnet/aspnetcore/issues/51222
- https://github.com/dotnet/aspnetcore/issues/51482
- https://github.com/dotnet/aspnetcore/pull/52559

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-419]: https://bitwarden.atlassian.net/browse/PAS-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ