### PR TITLE
PAS433 Fix invite link

### DIFF
--- a/src/AdminConsole/Services/InvitationService.cs
+++ b/src/AdminConsole/Services/InvitationService.cs
@@ -44,8 +44,8 @@ public class InvitationService : IInvitationService
         // store
         _db.Invites.Add(inv);
         await _db.SaveChangesAsync();
-
-        var link = _httpContextAccessor.HttpContext!.Request.GetBaseUrl() + "/organization/join?code=" + Convert.ToBase64String(code);
+        
+        var link = $"{_httpContextAccessor.HttpContext!.Request.GetBaseUrl()}/organization/join?code={Uri.EscapeDataString(Convert.ToBase64String(code))}";
 
         // send email
         await _mailService.SendInviteAsync(inv, link);

--- a/src/AdminConsole/Services/InvitationService.cs
+++ b/src/AdminConsole/Services/InvitationService.cs
@@ -44,7 +44,7 @@ public class InvitationService : IInvitationService
         // store
         _db.Invites.Add(inv);
         await _db.SaveChangesAsync();
-        
+
         var link = $"{_httpContextAccessor.HttpContext!.Request.GetBaseUrl()}/organization/join?code={Uri.EscapeDataString(Convert.ToBase64String(code))}";
 
         // send email


### PR DESCRIPTION
### Ticket
- Closes [PAS-433](https://bitwarden.atlassian.net/browse/PAS-433)


### Description
We were previously using Razor's ActionContext and UriHelper to build the invite link sent to invited admins. The page was migrated to blazor and the uri manually constructed.  This keeps the InvitationService ignorant of where its being called from.  However, the UrlHelper previously escaped the uri being built.  This PR adds that escaping back in for the invite code.

### Shape
This uses `Uri.EscapeDataString(...)` on the generate code for the invite.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Manual testing of invites to ensure special characters were encoded correctly.

I did the following to ensure that my changes do not introduce security vulnerabilities:
- N/A


[PAS-433]: https://bitwarden.atlassian.net/browse/PAS-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ