### PR TITLE
PAS-417 | Improve UX when deleting application

### DIFF
--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml
@@ -97,7 +97,7 @@
 {
     <panel header="Attestation">
         <p>When attestation is enabled, you can choose to limit the authenticators used with your application.</p>
-        
+
         <div>
             <a class="btn-primary" href="/app/@Model.ApplicationId/settings/authenticators">View authenticators</a>
         </div>
@@ -115,20 +115,21 @@
     else
     {
         <form method="post" asp-page-handler="Delete">
-            <p>
-                If your app contains no credentials or was newly created, <strong>the app will be deleted immediately</strong>.
-            </p>
-            <p class="">If your app <strong>does contain credentials</strong>, the following will happen once you choose to delete the application:</p>
-    
-            <ul role="list" class="list-decimal list-inside my-2">
-                <li class="">No data will be deleted immediately.</li>
-                <li>Your API Keys will be frozen - meaning no authentication calls can be made.</li>
-                <li>Admins can cancel the process at any time. The API will return to normal behavior.</li>
-                <li>If the process has not been aborted within 30 days, data will be deleted permanently.</li>
-            </ul>
-    
+            @if (!Model.CanDeleteImmediately)
+            {
+                <p>
+                    Because your application contains credentials, <strong>you cannot delete it immediately</strong>. Instead, the following will happen once you choose to delete the application:
+                </p>
+
+                <ul role="list" class="list-decimal list-inside my-2">
+                    <li class="">No data will be deleted immediately.</li>
+                    <li>Your API Keys will be frozen - meaning no authentication calls can be made.</li>
+                    <li>Admins can cancel the process at any time. The API will return to normal behavior.</li>
+                    <li>If the process has not been aborted within 30 days, data will be deleted permanently.</li>
+                </ul>
+            }
+
             <div id="deleteApplication"></div>
-    
         </form>
     }
 </panel>

--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml.cs
@@ -53,6 +53,8 @@ public class SettingsModel : BaseExtendedPageModel
 
     public Application? Application { get; private set; }
 
+    public bool CanDeleteImmediately { get; private set; }
+
     public ICollection<PlanModel> Plans { get; } = new List<PlanModel>();
 
     [BindProperty]
@@ -64,11 +66,12 @@ public class SettingsModel : BaseExtendedPageModel
     private async Task InitializeAsync()
     {
         Organization = await _dataService.GetOrganizationWithDataAsync();
-        ApplicationId = _currentContext.AppId ?? String.Empty;
+        ApplicationId = _currentContext.AppId ?? string.Empty;
 
         var application = Organization.Applications.FirstOrDefault(x => x.Id == ApplicationId);
 
         Application = application ?? throw new InvalidOperationException("Application not found.");
+        CanDeleteImmediately = await _appService.CanDeleteApplicationImmediatelyAsync(ApplicationId);
 
         IsManualTokenGenerationEnabled = _currentContext.Features.IsGenerateSignInTokenEndpointEnabled;
         IsMagicLinksEnabled = _currentContext.Features.IsMagicLinksEnabled;
@@ -106,7 +109,7 @@ public class SettingsModel : BaseExtendedPageModel
 
         try
         {
-            var response = await _appService.MarkApplicationForDeletionAsync(applicationId, userName);
+            var response = await _appService.MarkDeleteApplicationAsync(applicationId, userName);
 
             return response.IsDeleted ? RedirectToPage("/Organization/Overview") : RedirectToPage();
         }

--- a/src/AdminConsole/Services/ApplicationService.cs
+++ b/src/AdminConsole/Services/ApplicationService.cs
@@ -30,7 +30,10 @@ public class ApplicationService : IApplicationService
         _magicLinkBuilder = magicLinkBuilder;
     }
 
-    public async Task<MarkDeleteApplicationResponse> MarkApplicationForDeletionAsync(string applicationId, string userName)
+    public async Task<bool> CanDeleteApplicationImmediatelyAsync(string applicationId) =>
+        await _client.CanDeleteApplicationImmediatelyAsync(applicationId);
+
+    public async Task<MarkDeleteApplicationResponse> MarkDeleteApplicationAsync(string applicationId, string userName)
     {
         var response = await _client.MarkDeleteApplicationAsync(new MarkDeleteApplicationRequest(applicationId, userName));
 

--- a/src/AdminConsole/Services/IApplicationService.cs
+++ b/src/AdminConsole/Services/IApplicationService.cs
@@ -5,7 +5,8 @@ namespace Passwordless.AdminConsole.Services;
 
 public interface IApplicationService
 {
-    Task<MarkDeleteApplicationResponse> MarkApplicationForDeletionAsync(string applicationId, string userName);
+    Task<bool> CanDeleteApplicationImmediatelyAsync(string applicationId);
+    Task<MarkDeleteApplicationResponse> MarkDeleteApplicationAsync(string applicationId, string userName);
     Task CancelDeletionForApplicationAsync(string applicationId);
     Task<Onboarding?> GetOnboardingAsync(string applicationId);
     Task DeleteAsync(string applicationId);

--- a/src/AdminConsole/Services/PasswordlessManagement/IPasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/IPasswordlessManagementClient.cs
@@ -6,6 +6,7 @@ namespace Passwordless.AdminConsole.Services.PasswordlessManagement;
 public interface IPasswordlessManagementClient
 {
     Task<CreateAppResultDto> CreateApplicationAsync(string appId, CreateAppDto options);
+    Task<bool> CanDeleteApplicationImmediatelyAsync(string appId);
     Task<MarkDeleteApplicationResponse> MarkDeleteApplicationAsync(MarkDeleteApplicationRequest request);
     Task<bool> DeleteApplicationAsync(string appId);
     Task<CancelApplicationDeletionResponse> CancelApplicationDeletionAsync(string appId);

--- a/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
@@ -18,6 +18,11 @@ public class PasswordlessManagementClient(HttpClient http) : IPasswordlessManage
         return await response.Content.ReadFromJsonAsync<CreateAppResultDto>();
     }
 
+    public async Task<bool> CanDeleteApplicationImmediatelyAsync(string appId) =>
+        await http.GetFromJsonAsync<bool>(
+            $"admin/apps/{Uri.EscapeDataString(appId)}/can-delete-immediately"
+        );
+
     public async Task<MarkDeleteApplicationResponse> MarkDeleteApplicationAsync(MarkDeleteApplicationRequest request)
     {
         using var response = await http.PostAsJsonAsync(

--- a/src/Api/Endpoints/Apps.cs
+++ b/src/Api/Endpoints/Apps.cs
@@ -96,6 +96,10 @@ public static class AppsEndpoints
             .RequireManagementKey()
             .RequireCors("default");
 
+        app.MapGet("/admin/apps/{appId}/can-delete-immediately", CanDeleteApplicationImmediatelyAsync)
+            .RequireManagementKey()
+            .RequireCors("default");
+
         app.MapPost("/admin/apps/{appId}/mark-delete", MarkDeleteApplicationAsync)
             .RequireManagementKey()
             .RequireCors("default");
@@ -258,6 +262,14 @@ public static class AppsEndpoints
         var result = await service.DeleteApplicationAsync(appId);
         logger.LogWarning("account/delete was issued {@Res}", result);
         return Ok(result);
+    }
+
+    public static async Task<IResult> CanDeleteApplicationImmediatelyAsync(
+        [FromRoute] string appId,
+        ISharedManagementService service)
+    {
+        var result = await service.CanDeleteApplicationImmediatelyAsync(appId);
+        return Ok(false);
     }
 
     public static async Task<IResult> MarkDeleteApplicationAsync(

--- a/src/Api/Endpoints/Apps.cs
+++ b/src/Api/Endpoints/Apps.cs
@@ -269,7 +269,7 @@ public static class AppsEndpoints
         ISharedManagementService service)
     {
         var result = await service.CanDeleteApplicationImmediatelyAsync(appId);
-        return Ok(false);
+        return Ok(result);
     }
 
     public static async Task<IResult> MarkDeleteApplicationAsync(

--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -243,7 +243,8 @@ public class SharedManagementService : ISharedManagementService
 
         if (accountInformation.DeleteAt > _systemClock.UtcNow)
         {
-            throw new ApiException("app_pending_deletion", "App cannot be deleted yet.", 400);
+            // Maybe this should have a different error code?
+            throw new ApiException("app_not_pending_deletion", "App cannot be deleted yet.", 400);
         }
 
         await storage.DeleteAccount();

--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -25,6 +25,7 @@ public interface ISharedManagementService
     Task<ValidatePublicKeyDto> ValidatePublicKeyAsync(string publicKey);
     Task FreezeAccountAsync(string accountName);
     Task UnFreezeAccountAsync(string accountName);
+    Task<bool> CanDeleteApplicationImmediatelyAsync(string appId);
     Task<AppDeletionResult> DeleteApplicationAsync(string appId);
     Task<AppDeletionResult> MarkDeleteApplicationAsync(string appId, string deletedBy, string baseUrl);
     Task<IEnumerable<string>> GetApplicationsPendingDeletionAsync();
@@ -208,6 +209,23 @@ public class SharedManagementService : ISharedManagementService
         await storage.SetAppDeletionDate(null);
     }
 
+    public async Task<bool> CanDeleteApplicationImmediatelyAsync(string appId)
+    {
+        var storage = tenantFactory.Create(appId);
+        var accountInformation = await storage.GetAccountInformation();
+        if (accountInformation == null)
+        {
+            throw new ApiException("app_not_found", "App was not found.", 400);
+        }
+
+        // Application can be deleted immediately if...
+        return
+            // It's less than 3 days old, or...
+            (accountInformation.CreatedAt - _systemClock.UtcNow) < TimeSpan.FromDays(3) ||
+            // It has no users
+            !(await storage.HasUsersAsync());
+    }
+
     public async Task<AppDeletionResult> DeleteApplicationAsync(string appId)
     {
         var storage = tenantFactory.Create(appId);
@@ -218,9 +236,14 @@ public class SharedManagementService : ISharedManagementService
             throw new ApiException("app_not_found", "App was not found.", 400);
         }
 
-        if (!accountInformation.DeleteAt.HasValue || accountInformation.DeleteAt > _systemClock.UtcNow)
+        if (!accountInformation.DeleteAt.HasValue)
         {
             throw new ApiException("app_not_pending_deletion", "App was not scheduled for deletion.", 400);
+        }
+
+        if (accountInformation.DeleteAt > _systemClock.UtcNow)
+        {
+            throw new ApiException("app_pending_deletion", "App cannot be deleted yet.", 400);
         }
 
         await storage.DeleteAccount();
@@ -229,7 +252,8 @@ public class SharedManagementService : ISharedManagementService
             $"The app '{accountInformation.AcountName}' was deleted.",
             true,
             _systemClock.UtcNow.UtcDateTime,
-            accountInformation.AdminEmails);
+            accountInformation.AdminEmails
+        );
     }
 
     public async Task<AppDeletionResult> MarkDeleteApplicationAsync(string appId, string deletedBy, string baseUrl)
@@ -246,21 +270,17 @@ public class SharedManagementService : ISharedManagementService
             throw new ApiException("app_pending_deletion", "App is already pending to be deleted.", 400);
         }
 
-        bool canDeleteImmediately = accountInformation.CreatedAt > _systemClock.UtcNow.AddDays(-3);
-
-        if (!canDeleteImmediately)
-        {
-            canDeleteImmediately = !(await storage.HasUsersAsync());
-        }
-
+        var canDeleteImmediately = await CanDeleteApplicationImmediatelyAsync(appId);
         if (canDeleteImmediately)
         {
             await storage.DeleteAccount();
+
             return new AppDeletionResult(
                 $"The app '{accountInformation.AcountName}' was deleted.",
                 true,
                 _systemClock.UtcNow.UtcDateTime,
-                accountInformation.AdminEmails);
+                accountInformation.AdminEmails
+            );
         }
 
         // Lock/Freeze all API keys that have been issued.

--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -221,7 +221,7 @@ public class SharedManagementService : ISharedManagementService
         // Application can be deleted immediately if...
         return
             // It's less than 3 days old, or...
-            (accountInformation.CreatedAt - _systemClock.UtcNow) < TimeSpan.FromDays(3) ||
+            (_systemClock.UtcNow - accountInformation.CreatedAt) < TimeSpan.FromDays(3) ||
             // It has no users
             !(await storage.HasUsersAsync());
     }

--- a/tests/Service.Tests/Implementations/SharedManagementServiceTests.cs
+++ b/tests/Service.Tests/Implementations/SharedManagementServiceTests.cs
@@ -77,7 +77,7 @@ public class SharedManagementServiceTests
             AcountName = appId,
             CreatedAt = _now.AddDays(-1),
             Tenant = appId,
-            AdminEmails = new[] { deletedBy }
+            AdminEmails = [deletedBy]
         };
 
         tenantStorageMock.Setup(x => x.GetAccountInformation())
@@ -110,7 +110,7 @@ public class SharedManagementServiceTests
             AcountName = appId,
             CreatedAt = _now.AddDays(-4),
             Tenant = appId,
-            AdminEmails = new[] { deletedBy }
+            AdminEmails = [deletedBy]
         };
 
         tenantStorageMock.Setup(x => x.GetAccountInformation())
@@ -142,7 +142,7 @@ public class SharedManagementServiceTests
             AcountName = appId,
             CreatedAt = _now.AddDays(-365),
             Tenant = appId,
-            AdminEmails = new[] { deletedBy }
+            AdminEmails = [deletedBy]
         };
         tenantStorageMock.Setup(x => x.GetAccountInformation())
             .ReturnsAsync(accountInformation);
@@ -174,7 +174,7 @@ public class SharedManagementServiceTests
             AcountName = appId,
             CreatedAt = _now.AddDays(-365),
             Tenant = appId,
-            AdminEmails = new[] { deletedBy }
+            AdminEmails = [deletedBy]
         };
         tenantStorageMock.Setup(x => x.GetAccountInformation())
             .ReturnsAsync(accountInformation);
@@ -227,7 +227,7 @@ public class SharedManagementServiceTests
             AcountName = appId,
             DeleteAt = _now.AddDays(-1),
             Tenant = appId,
-            AdminEmails = new[] { "admin@email.com" }
+            AdminEmails = ["admin@email.com"]
         };
         tenantStorageMock.Setup(x => x.GetAccountInformation())
             .ReturnsAsync(accountInformation);
@@ -255,7 +255,7 @@ public class SharedManagementServiceTests
             AcountName = appId,
             DeleteAt = _now.AddDays(1),
             Tenant = appId,
-            AdminEmails = new[] { "admin@email.com" }
+            AdminEmails = ["admin@email.com"]
         };
         tenantStorageMock.Setup(x => x.GetAccountInformation())
             .ReturnsAsync(accountInformation);
@@ -268,7 +268,7 @@ public class SharedManagementServiceTests
 
         Assert.Equal("app_not_pending_deletion", actual.ErrorCode);
         Assert.Equal(400, actual.StatusCode);
-        Assert.Equal("App was not scheduled for deletion.", actual.Message);
+        Assert.Equal("App cannot be deleted yet.", actual.Message);
 
         tenantStorageMock.Verify(x => x.DeleteAccount(), Times.Never);
     }
@@ -364,29 +364,29 @@ public class SharedManagementServiceTests
         const string appId = "test";
         var storageMock = new Mock<ITenantStorage>();
         _tenantStorageFactoryMock.Setup(x => x.Create(It.Is<string>(p => p == appId))).Returns(storageMock.Object);
-        storageMock.Setup(x => x.GetAllApiKeys()).ReturnsAsync(new List<ApiKeyDesc>
-        {
+        storageMock.Setup(x => x.GetAllApiKeys()).ReturnsAsync([
             new()
             {
                 Tenant = "test",
                 ApiKey = "test:public:2e728aa5986f4ba8b073a5b28a939795",
                 Id = "9795",
-                Scopes = new[] { "register", "login" },
+                Scopes = ["register", "login"],
                 IsLocked = false,
                 LastLockedAt = new DateTime(2023, 10, 1),
                 LastUnlockedAt = new DateTime(2023, 10, 2)
             },
+
             new()
             {
                 Tenant = "test",
                 ApiKey = "Wx9XPDW1cp1Jb0LxElrh+g==:/7E93JhN30boFyNyVbCW/g==",
                 Id = "6d02",
-                Scopes = new[] { "token_register", "token_verify" },
+                Scopes = ["token_register", "token_verify"],
                 IsLocked = true,
                 LastLockedAt = new DateTime(2023, 11, 1),
                 LastUnlockedAt = null
             }
-        });
+        ]);
 
         // act
         var actual = await _sut.ListApiKeysAsync(appId);


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-417](https://bitwarden.atlassian.net/browse/PAS-417)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

This simplifies the informational burden on the "delete" section of the application settings page. Instead of outlining all possible scenarios (which are kind of hard to understand because we have several conditions for whether an app can be deleted immediately), the page will now only show the information relevant to the specific app the user is attempting to delete.

### Shape

- When the settings page is loaded, AC queries the API to check if the app can be deleted immediately
- To do that, a new endpoint `{app-id}/can-delete-immediately` was added, which returns JSON-encoded `bool`

### Screenshots

App has no users OR has been created <3 days ago:

<img width="925" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1935960/d14b15db-bb4f-42ce-82c9-552a7e106cd4">

App has users AND has been created >=3 days ago:

<img width="863" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1935960/a004edbe-fc22-4680-a46c-ac5a5cda9007">


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-417]: https://bitwarden.atlassian.net/browse/PAS-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ