### PR TITLE
Return .NET runtime version

### DIFF
--- a/src/Common/HealthChecks/VersionHealthCheck.cs
+++ b/src/Common/HealthChecks/VersionHealthCheck.cs
@@ -15,7 +15,8 @@ public class VersionHealthCheck : IHealthCheck
             {
                 ["version"] = assembly.GetInformationalVersion() ??
                               assembly.GetName().Version?.ToString() ??
-                              "unknown version"
+                              "unknown version",
+                ["net-runtime-version"] = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
             })
         );
     }


### PR DESCRIPTION
### Description

Return the .NET runtime version at least for the time being. This can help us diagnose specific bugs that we've experienced in the past few weeks in relation to Blazor. You can obtain the dotnet runtime version for an Azure Web App, but you require write access.

### Shape

n/a

### Screenshots

```
{
    "status": "Healthy",
    "elapsedMilliseconds": 3.8932,
    "results": {
        "version": {
            "status": "Healthy",
            "elapsedMilliseconds": 0.8903,
            "data": {
                "version": "1.0.0+476e82a3acc6e7549b7c450bfe4d8d3a2d4ab9a0",
                "net-runtime": ".NET 8.0.4"
            }
        }
    }
}
```

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- See screenshots

I did the following to ensure that my changes do not introduce security vulnerabilities:
- Exposing the .NET runtime could be a potential vulnerability. However, when publishing images, we'd essentially run into the same issue, as a specific version of Passwordless.dev is published at a specific point in time where specific dependent images are available at that point in time.