### PR TITLE
PAS-444 | Populate metered billing from periodic credential reports.

### DIFF
--- a/src/AdminConsole/Billing/BackgroundServices/MeteredBillingBackgroundService.cs
+++ b/src/AdminConsole/Billing/BackgroundServices/MeteredBillingBackgroundService.cs
@@ -1,5 +1,9 @@
+using Passwordless.AdminConsole.Db;
+using Passwordless.AdminConsole.Middleware;
 using Passwordless.AdminConsole.Services;
 using Passwordless.Common.Background;
+using Passwordless.Common.Models.Reporting;
+using Stripe;
 
 namespace Passwordless.AdminConsole.Billing.BackgroundServices;
 
@@ -17,8 +21,71 @@ public sealed class MeteredBillingBackgroundService(
         try
         {
             using IServiceScope scope = services.CreateScope();
-            var billingService = scope.ServiceProvider.GetRequiredService<ISharedBillingService>();
-            await billingService.UpdateUsageAsync();
+            var db = scope.ServiceProvider.GetRequiredService<ConsoleDbContext>();
+            var timeProvider = scope.ServiceProvider.GetRequiredService<TimeProvider>();
+
+            // 1. Retrieve all paid organizations.
+            var sharedBillingService = scope.ServiceProvider.GetRequiredService<ISharedBillingService>();
+            var organizations = await sharedBillingService.GetPayingOrganizationsAsync();
+
+            // 2. Populate how many unique users per application we have.
+            Logger.LogInformation("Updating metered billing for {Organizations} organizations.", organizations.Count);
+            foreach (var organization in organizations)
+            {
+                var items = new Dictionary<string, int>();
+
+                foreach (var application in organization.Applications)
+                {
+                    Logger.LogInformation("Processing metered billing for application '{Application}'.", application.Id);
+
+                    var context = scope.ServiceProvider.GetRequiredService<ICurrentContext>();
+                    context.SetApp(application);
+
+                    var request = new PeriodicCredentialReportRequest(DateOnly.FromDateTime(timeProvider.GetUtcNow().Date.AddDays(-1)), null);
+                    var api = scope.ServiceProvider.GetRequiredService<IScopedPasswordlessClient>();
+                    var reports = await api.GetPeriodicCredentialReportsAsync(request);
+                    var report = reports.LastOrDefault();
+
+                    if (report == null) continue;
+
+                    if (items.ContainsKey(application.BillingSubscriptionItemId))
+                    {
+                        items[application.BillingSubscriptionItemId] += report.Users;
+                    }
+                    else
+                    {
+                        items.Add(application.BillingSubscriptionItemId, report.Users);
+                    }
+                }
+
+                // 3. Update the usage records.
+                foreach (var item in items)
+                {
+                    var idempotencyKey = Guid.NewGuid().ToString();
+                    var service = new UsageRecordService();
+                    try
+                    {
+                        await service.CreateAsync(
+                            item.Key,
+                            new UsageRecordCreateOptions
+                            {
+                                Quantity = item.Value,
+                                Timestamp = DateTime.UtcNow,
+                                Action = "set"
+                            },
+                            new RequestOptions
+                            {
+                                IdempotencyKey = idempotencyKey
+                            }
+                        );
+                    }
+                    catch (StripeException e)
+                    {
+                        Logger.LogError("Usage report failed for item {BillingSubscriptionItemId}:", item.Key);
+                        Logger.LogError(e, "Idempotency key: {IdempotencyKey}.", idempotencyKey);
+                    }
+                }
+            }
         }
         catch (Exception e)
         {

--- a/src/AdminConsole/Billing/NoOpBillingService.cs
+++ b/src/AdminConsole/Billing/NoOpBillingService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.Options;
 using Passwordless.AdminConsole.Billing.Configuration;
 using Passwordless.AdminConsole.Db;
@@ -18,16 +17,14 @@ public class NoOpBillingService : BaseBillingService, ISharedBillingService
         IPasswordlessManagementClient passwordlessClient,
         ILogger<SharedStripeBillingService> logger,
         IOptions<BillingOptions> billingOptions,
-        IHttpContextAccessor httpContextAccessor,
-        IUrlHelperFactory urlHelperFactory
-    ) : base(db, dataService, passwordlessClient, logger, billingOptions, httpContextAccessor, urlHelperFactory)
+        IHttpContextAccessor httpContextAccessor
+    ) : base(db, dataService, passwordlessClient, logger, billingOptions, httpContextAccessor)
     {
     }
 
-    public Task UpdateUsageAsync()
+    public Task<IReadOnlyCollection<Organization>> GetPayingOrganizationsAsync()
     {
-        // This can be a no-op.
-        return Task.CompletedTask;
+        return Task.FromResult<IReadOnlyCollection<Organization>>(Array.Empty<Organization>().ToImmutableList());
     }
 
     public Task<IReadOnlyCollection<PaymentMethodModel>> GetPaymentMethods(string? organizationBillingCustomerId)

--- a/src/AdminConsole/Services/ISharedBillingService.cs
+++ b/src/AdminConsole/Services/ISharedBillingService.cs
@@ -5,11 +5,7 @@ namespace Passwordless.AdminConsole.Services;
 
 public interface ISharedBillingService
 {
-    /// <summary>
-    /// Updates the seats used for every app in the organization which are relevant for metered subscriptions.
-    /// </summary>
-    /// <returns></returns>
-    Task UpdateUsageAsync();
+    Task<IReadOnlyCollection<Organization>> GetPayingOrganizationsAsync();
 
     Task<IReadOnlyCollection<PaymentMethodModel>> GetPaymentMethods(string? organizationBillingCustomerId);
 


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-444](https://bitwarden.atlassian.net/browse/PAS-444)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

This is the first step to populate metered billing from periodic credential reports in the api. Stripe recommends we keep the usage records ourselves, so for this the periodic credential reports will serve their purpose.

In step 2 of the refactoring, we will stop updating the CurrentUserCount in the Applications table periodically, but instead do it upon login of an admin to significantly reduce network traffic.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots

For testing I populated PeriodicCredentialReports first. Then forced the background job to run:

<img width="565" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/1045327/c81a14be-2cfc-4dd1-9e83-f70ffb21452f">

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Tested locally.

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-444]: https://bitwarden.atlassian.net/browse/PAS-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ