### PR TITLE
PAS-448 | update module style in reports

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Reporting.razor
+++ b/src/AdminConsole/Components/Pages/App/Reporting.razor
@@ -107,8 +107,8 @@
         if (lastActiveUserReport != null)
         {
             double totalUsers = lastActiveUserReport.TotalUsers;
-            SummaryItems.Add(new TrendingCardsStats.Item("Daily Active Users", lastActiveUserReport.DailyActiveUsers, TrendingCardsStats.ValueTypes.Integer, "({0} of total)", lastActiveUserReport.DailyActiveUsers / totalUsers, TrendingCardsStats.ValueTypes.Percentage));
-            SummaryItems.Add(new TrendingCardsStats.Item("Weekly Active Users", lastActiveUserReport.WeeklyActiveUsers, TrendingCardsStats.ValueTypes.Integer, "({0} of total)", lastActiveUserReport.WeeklyActiveUsers / totalUsers, TrendingCardsStats.ValueTypes.Percentage));
+            SummaryItems.Add(new TrendingCardsStats.Item("Daily Active Users", lastActiveUserReport.DailyActiveUsers, TrendingCardsStats.ValueTypes.Integer, "({0} of total)", totalUsers == 0 ? 0 : lastActiveUserReport.DailyActiveUsers / totalUsers, TrendingCardsStats.ValueTypes.Percentage));
+            SummaryItems.Add(new TrendingCardsStats.Item("Weekly Active Users", lastActiveUserReport.WeeklyActiveUsers, TrendingCardsStats.ValueTypes.Integer, "({0} of total)", totalUsers == 0 ? 0 : lastActiveUserReport.WeeklyActiveUsers / totalUsers, TrendingCardsStats.ValueTypes.Percentage));
         }
         return true;
     }

--- a/src/AdminConsole/Components/Shared/Stats/TrendingCardsStats.razor
+++ b/src/AdminConsole/Components/Shared/Stats/TrendingCardsStats.razor
@@ -42,7 +42,7 @@
         public string GetValue() => Format(Value, Type);
         
         public string GetSubValue() => Format(SubValue, SubType);
-        
+
         private string Format(double value, ValueTypes type)
         {
             switch (type)
@@ -52,7 +52,7 @@
                 case ValueTypes.Integer:
                     return value.ToString("N0", CultureInfo.InvariantCulture);
                 case ValueTypes.Percentage:
-                    return value.ToString("P2", CultureInfo.InvariantCulture);
+                    return value.ToString("P2", CultureInfo.InvariantCulture).Replace(" ", string.Empty);
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/AdminConsole/Components/Shared/Stats/TrendingCardsStats.razor
+++ b/src/AdminConsole/Components/Shared/Stats/TrendingCardsStats.razor
@@ -1,16 +1,19 @@
 @using System.Globalization
 @inherits BaseCardStats
 
+
 @if (Items.Count > 0)
 {
     <dl class="@Class">
         @foreach (var item in Items)
         {
-            <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8">
-                <dt class="text-sm font-medium leading-6 text-gray-500">@item.Label</dt>
-                <dd class="text-xs font-medium text-gray-700">@string.Format(item.SubLabel, item.GetSubValue())</dd>
-                <dd class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900">@item.GetValue()</dd>
-            </div>
+            <Panel>
+                <div class="flex flex-wrap items-baseline justify-between">
+                    <dt class="text-sm font-medium leading-6 text-gray-500">@item.Label</dt>
+                    <dd class="text-xs font-medium text-gray-700">@string.Format(item.SubLabel, item.GetSubValue())</dd>
+                    <dd class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900">@item.GetValue()</dd>
+                </div>
+            </Panel>
         }
     </dl>
 }

--- a/tests/AdminConsole.Tests/Components/Shared/Stats/TrendingCardsStatsTests.cs
+++ b/tests/AdminConsole.Tests/Components/Shared/Stats/TrendingCardsStatsTests.cs
@@ -56,9 +56,9 @@ public class TrendingCardsStatsTests : TestContext
 
         // Assert
         var cards = cut.Nodes[0].ChildNodes;
-        cards[0].MarkupMatches("<div diff:ignoreAttributes><dt diff:ignoreAttributes>Title 1</dt><dd diff:ignoreAttributes>Sub 4.00 %</dd><dd diff:ignoreAttributes>1</dd></div>");
-        cards[1].MarkupMatches("<div diff:ignoreAttributes><dt diff:ignoreAttributes>Title 2</dt><dd diff:ignoreAttributes>Sub 2.00 %</dd><dd diff:ignoreAttributes>2.00</dd></div>");
-        cards[2].MarkupMatches("<div diff:ignoreAttributes><dt diff:ignoreAttributes>Title 3</dt><dd diff:ignoreAttributes>Sub 1</dd><dd diff:ignoreAttributes>300.00 %</dd></div>");
+        cards[0].MarkupMatches("<div diff:ignoreAttributes><div diff:ignoreAttributes><div diff:ignoreAttributes><dt diff:ignoreAttributes>Title 1</dt><dd diff:ignoreAttributes>Sub 4.00%</dd><dd diff:ignoreAttributes>1</dd></div></div></div>");
+        cards[1].MarkupMatches("<div diff:ignoreAttributes><div diff:ignoreAttributes><div diff:ignoreAttributes><dt diff:ignoreAttributes>Title 2</dt><dd diff:ignoreAttributes>Sub 2.00%</dd><dd diff:ignoreAttributes>2.00</dd></div></div></div>");
+        cards[2].MarkupMatches("<div diff:ignoreAttributes><div diff:ignoreAttributes><div diff:ignoreAttributes><dt diff:ignoreAttributes>Title 3</dt><dd diff:ignoreAttributes>Sub 1</dd><dd diff:ignoreAttributes>300.00%</dd></div></div></div>");
     }
 
     [Fact]


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-448](https://bitwarden.atlassian.net/browse/PAS-448)

### Description
<!--
    Introduction that should allow the reviewer to quickly be able to understand the reason for opening this PR.
-->
* adds `<Panel>` container to the top two modules in the reports page so that they match the module with the graphs
* fixes an issue i saw in top modules where "NaN of total" will show with a new org that doesn't have any users yet

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->
| Before    | After |
| -------- | ------- |
| <img width="1694" alt="Screenshot 2024-05-09 at 11 23 16 AM" src="https://github.com/bitwarden/passwordless-server/assets/14082576/7e2c95a3-489d-4384-b5ac-f27878a1262b">  | <img width="1703" alt="Screenshot 2024-05-09 at 11 25 26 AM" src="https://github.com/bitwarden/passwordless-server/assets/14082576/00dacd1b-05c0-48f4-aca5-be99eabb8ae5"> |
| <img width="418" alt="Screenshot 2024-05-09 at 11 24 06 AM" src="https://github.com/bitwarden/passwordless-server/assets/14082576/79cf9355-645a-4204-a20d-9b8b30c7b256"> | <img width="418" alt="Screenshot 2024-05-09 at 11 24 45 AM" src="https://github.com/bitwarden/passwordless-server/assets/14082576/17c2eb70-5b19-4d6e-9d4d-164596a580b8"> |



[PAS-448]: https://bitwarden.atlassian.net/browse/PAS-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ