### PR TITLE
Exclude .NET SDK from being upgraded with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,5 @@
       "matchUpdateTypes": ["minor", "patch"]
     }
   ],
-  "ignoreDeps": ["Datadog.Trace"]
+  "ignoreDeps": ["Datadog.Trace", "dotnet-sdk"]
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.203",
-    "rollForward": "latestMinor"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
### Description

n/a

### Shape

- Do not roll forward to the latest minor .NET SDK to avoid unexpected behavior.
- Renovate should not suggest to update the `global.json`.

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
