### PR TITLE
Inject `ISharedManagementService` request scoped instead of transient.

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -68,7 +68,7 @@ services.ConfigureHttpJsonOptions(options =>
 });
 
 services.AddDatabase(builder.Configuration);
-services.AddTransient<ISharedManagementService, SharedManagementService>();
+services.AddScoped<ISharedManagementService, SharedManagementService>();
 services.AddScoped<UserCredentialsService>();
 services.AddScoped<IReportingService, ReportingService>();
 services.AddScoped<IApplicationService, ApplicationService>();

--- a/src/Service/SharedManagementService.cs
+++ b/src/Service/SharedManagementService.cs
@@ -44,18 +44,16 @@ public class SharedManagementService : ISharedManagementService
     private readonly ILogger _logger;
     private readonly IEventLogger _eventLogger;
     private readonly ISystemClock _systemClock;
-    private readonly ITenantStorage _tenantStorage;
     private readonly ITenantStorageFactory tenantFactory;
     private readonly IGlobalStorage _storage;
 
-    public SharedManagementService(ITenantStorage tenantStorage,
+    public SharedManagementService(
         ITenantStorageFactory tenantFactory,
         IGlobalStorage storage,
         ISystemClock systemClock,
         ILogger<SharedManagementService> logger,
         IEventLogger eventLogger)
     {
-        _tenantStorage = tenantStorage;
         this.tenantFactory = tenantFactory;
         _storage = storage;
         _systemClock = systemClock;

--- a/tests/Service.Tests/Implementations/SharedManagementServiceTests.cs
+++ b/tests/Service.Tests/Implementations/SharedManagementServiceTests.cs
@@ -13,7 +13,6 @@ namespace Passwordless.Service.Tests.Implementations;
 
 public class SharedManagementServiceTests
 {
-    private readonly Mock<ITenantStorage> _tenantStorageMock = new();
     private readonly Mock<ITenantStorageFactory> _tenantStorageFactoryMock = new();
     private readonly Mock<IGlobalStorage> _storageMock = new();
     private readonly Mock<ISystemClock> _systemClockMock = new();
@@ -27,7 +26,6 @@ public class SharedManagementServiceTests
     public SharedManagementServiceTests()
     {
         _sut = new SharedManagementService(
-            _tenantStorageMock.Object,
             _tenantStorageFactoryMock.Object,
             _storageMock.Object,
             _systemClockMock.Object,


### PR DESCRIPTION
### Description

Can potentially save a little bit of memory by injecting it request scoped instead of transient. `ITenantStorage` was also nowhere being referenced any longer.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Verified everything was working properly.
- Integration tests executed.

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
