### PR TITLE
PAS-464 | Disable rate limiter globally

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -148,7 +148,6 @@ app.UseWhen(o =>
 });
 app.UseAuthentication();
 app.UseAuthorization();
-app.UseRateLimiter();
 app.UseMiddleware<LoggingMiddleware>();
 app.UseSerilog();
 app.UseWhen(o =>


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-464](https://bitwarden.atlassian.net/browse/PAS-464)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

The rate limiter appears to have been activated globally, which was only intended for magic links.

### Shape

We were only supposed to be using a rate limiter for magic links.

When using the admin console, you can currently trip the rate limiter for the management key, basically causing the whole admin console and its background jobs to break.

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
