### PR TITLE
PAS-455 | Fix magic links for self-hosted instances

### DIFF
--- a/self-host/entrypoint.sh
+++ b/self-host/entrypoint.sh
@@ -154,8 +154,11 @@ if [ "$api_key" == "null" ] || [ "$api_secret" == "null" ] || [ "$management_key
   mv "$mounted_temp" "$mounted_config"
 fi
 
+# Magic Links
+export MagicLinks__NewAccountTimeout="0.00:00:00"
+
 # Configure overrides for the admin console app
-jq '.ApplicationOverrides.adminconsole.IsRateLimitBypassEnabled = true | .ApplicationOverrides.adminconsole.IsMagicLinkQuotaBypassEnabled = true' \
+jq '.ApplicationOverrides.admin.IsRateLimitBypassEnabled = true | .ApplicationOverrides.admin.IsMagicLinkQuotaBypassEnabled = true' \
   "$mounted_config" > "$mounted_temp"
 mv "$mounted_temp" "$mounted_config"
 

--- a/self-host/entrypoint.sh
+++ b/self-host/entrypoint.sh
@@ -154,11 +154,8 @@ if [ "$api_key" == "null" ] || [ "$api_secret" == "null" ] || [ "$management_key
   mv "$mounted_temp" "$mounted_config"
 fi
 
-# Magic Links
-export MagicLinks__NewAccountTimeout="0.00:00:00"
-
 # Configure overrides for the admin console app
-jq '.ApplicationOverrides.admin.IsRateLimitBypassEnabled = true | .ApplicationOverrides.admin.IsMagicLinkQuotaBypassEnabled = true' \
+jq '.ApplicationOverrides.adminconsole.IsRateLimitBypassEnabled = true | .ApplicationOverrides.adminconsole.IsMagicLinkQuotaBypassEnabled = true' \
   "$mounted_config" > "$mounted_temp"
 mv "$mounted_temp" "$mounted_config"
 

--- a/self-host/entrypoint.sh
+++ b/self-host/entrypoint.sh
@@ -154,6 +154,9 @@ if [ "$api_key" == "null" ] || [ "$api_secret" == "null" ] || [ "$management_key
   mv "$mounted_temp" "$mounted_config"
 fi
 
+# Magic Links
+export MagicLinks__NewAccountTimeout="0.00:00:00"
+
 # Configure overrides for the admin console app
 jq '.ApplicationOverrides.admin.IsRateLimitBypassEnabled = true | .ApplicationOverrides.admin.IsMagicLinkQuotaBypassEnabled = true' \
   "$mounted_config" > "$mounted_temp"


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-455](https://bitwarden.atlassian.net/browse/PAS-455)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

Disables the magic links quota enforcement in a self-hosted environment, so that customers that spin up new instances can create new applications that are not the same as the admin e-mail that was used to setup Passwordless.dev for the first time.

### Shape

When a new self-hosted instance is being spun up, you're being asked to enter your name and e-mail for the administrator account managing the Passwordless.dev self-hosted instance. But e-mails can only be sent out to the admin e-mails contained in the `adminconsole` application.

If you then want to create a new organization using a different e-mail address than the one mentioned above, you cannot do so as there was a 24h period which only allows the initial admin to receive magic links.

In our cloud-hosted product, this is not a problem.

I personally would completely remove the quota enforcement defined  `src/Service/MagicLinks/MagicLinkService`. As it causes a reverse dependency for the api to depend on the admin console.

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-455]: https://bitwarden.atlassian.net/browse/PAS-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ