### PR TITLE
fix-razor-path-for-client-js

### DIFF
--- a/src/AdminConsole/Components/App.razor
+++ b/src/AdminConsole/Components/App.razor
@@ -8,7 +8,7 @@
     <SecureStylesheet href="css/site.css" />
     <SecureStylesheet href="css/tailwind.css" />
     <HeadOutlet/>
-    <SecureScript src="~/lib/passwordless/passwordless.umd.min.js" />
+    <SecureScript src="lib/passwordless/passwordless.umd.min.js" />
 </head>
 
 <body class="h-full bg-gray-50">


### PR DESCRIPTION
### Ticket
- Closes [PAS-397](https://bitwarden.atlassian.net/browse/PAS-397)

### Description
Corrects the path for the passwordless client lib on blazor pages.

### Shape
Remvoes the `~` from the `SecureScript` path when adding the passwordless client lib. Otherwise it returned a 404.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Visited razor pages, blazor components in razor pages, and blazor pages to validate errors weren't thrown in console.


[PAS-397]: https://bitwarden.atlassian.net/browse/PAS-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ