### PR TITLE
Removed `.` from allowed characters

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/AuthenticationConfiguration/AuthenticationConfigurationFormModel.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/AuthenticationConfiguration/AuthenticationConfigurationFormModel.cs
@@ -6,7 +6,7 @@ namespace Passwordless.AdminConsole.Components.Pages.App.Settings.Authentication
 
 public class AuthenticationConfigurationFormModel
 {
-    [Required, MinLength(1), RegularExpression(@"^[\w\-\.]*$", ErrorMessage = "Characters are limited to A-z, 0-9, -, ., or _.")]
+    [Required, MinLength(1), RegularExpression(@"^[\w\-]*$", ErrorMessage = "Characters are limited to A-z, 0-9, -, or _.")]
     public string Purpose { get; set; } = string.Empty;
 
     [Required] public UserVerificationRequirement UserVerificationRequirement { get; set; } = UserVerificationRequirement.Preferred;

--- a/src/AdminConsole/Components/Pages/App/Settings/AuthenticationConfiguration/AuthenticationConfigurationFormModel.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/AuthenticationConfiguration/AuthenticationConfigurationFormModel.cs
@@ -6,7 +6,7 @@ namespace Passwordless.AdminConsole.Components.Pages.App.Settings.Authentication
 
 public class AuthenticationConfigurationFormModel
 {
-    [Required, MinLength(1), RegularExpression(@"^[\w\-]*$", ErrorMessage = "Characters are limited to A-z, 0-9, -, or _.")]
+    [Required(AllowEmptyStrings = false), RegularExpression(@"^[\w\-]*$", ErrorMessage = "Characters are limited to A-z, 0-9, -, or _."), MaxLength(255)]
     public string Purpose { get; set; } = string.Empty;
 
     [Required] public UserVerificationRequirement UserVerificationRequirement { get; set; } = UserVerificationRequirement.Preferred;

--- a/src/Common/Models/Apps/SetAuthenticationConfigurationRequest.cs
+++ b/src/Common/Models/Apps/SetAuthenticationConfigurationRequest.cs
@@ -6,7 +6,7 @@ namespace Passwordless.Common.Models.Apps;
 
 public class SetAuthenticationConfigurationRequest
 {
-    [Required(AllowEmptyStrings = false)]
+    [Required(AllowEmptyStrings = false), RegularExpression(@"^[\w\-]*$", ErrorMessage = "Characters are limited to A-z, 0-9, -, or _."), MaxLength(255)]
     public string Purpose { get; set; } = string.Empty;
     public UserVerificationRequirement UserVerificationRequirement { get; set; } = UserVerificationRequirement.Preferred;
     [PositiveTimeSpanValidator]


### PR DESCRIPTION

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-504](https://bitwarden.atlassian.net/browse/PAS-504)



### Description
`.` was not working for auth config name, so removed it from allowed characters.

### Shape
Removed `.` from allowed characters.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Manual test. Validation now fails with `.` in purpose.


[PAS-504]: https://bitwarden.atlassian.net/browse/PAS-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ