### PR TITLE
pas512-fix-playground-client

### DIFF
--- a/src/AdminConsole/Pages/App/Playground/Client.cshtml
+++ b/src/AdminConsole/Pages/App/Playground/Client.cshtml
@@ -179,8 +179,12 @@
                 autoFill(10);
 
                 const loginSubmit = async (e) => {
+                    const alias = e.target.alias.value;
                     if (isStepUp.value) {
-                        const {token, error} = await p.stepup({ signinMethod: { alias: alias }, purpose: selectedPurpose });
+                        const {token, error} = await p.stepup({
+                            signinMethod: { alias: alias },
+                            purpose: selectedPurpose.value
+                        });
 
                         if (token) {
                             await signin(token);
@@ -190,7 +194,6 @@
                             }
                         }
                     } else {
-                        const alias = e.target.alias.value;
                         const {token, error} = await p.signinWithAlias(alias);
                         if (token) {
                             await signin(token);

--- a/src/Service/Models/SignInBeginDTO.cs
+++ b/src/Service/Models/SignInBeginDTO.cs
@@ -6,7 +6,7 @@ namespace Passwordless.Service.Models;
 
 public class SignInBeginDTO : RequestBase
 {
-    public string Alias { get; set; }
+    public string Alias { get; init; }
     public string UserId { get; init; }
     [JsonConverter(typeof(SignInPurposeConverter))]
     public SignInPurpose Purpose { get; set; } = SignInPurpose.SignIn;


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-512](https://bitwarden.atlassian.net/browse/PAS-512)


### Description
Fixed setting the alias to be used by the client in the playground. Fixed the purpose being passed to step up to use value instead of the raw ref.

### Shape
Copy paste error resulting in an undefined alias and purpose not being set.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- verified i could register, sign in and step up with an alias in the playground

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-512]: https://bitwarden.atlassian.net/browse/PAS-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ