### PR TITLE
PAS-386 | Don't require restarting the app during Admin Console initialization

### DIFF
--- a/src/AdminConsole/Components/Pages/Initialize.razor
+++ b/src/AdminConsole/Components/Pages/Initialize.razor
@@ -29,7 +29,7 @@
         <p>The Admin Console is missing either migrations or ApiKeys for the Passwordless.dev API, proceed with the setup wizard below.</p>
 
         <p>Upon completing the form, a separate application in the Passwordless.dev API is created to hold the credentials for administrators of the Admin Console.</p>
-        
+
         <EditForm
             Model="Form"
             FormName="AdminConsoleCreateForm"
@@ -55,16 +55,16 @@
     {
         <p>@ProcessMessage</p>
     }
-    
+
     @if (PasswordlessOptions is not null)
     {
         <p><strong>Keep these values secret</strong>. Add these values to your Admin Console configuration:</p>
-        
+
         <code style="white-space: pre;" lang="json">@JsonSerializer.Serialize(PasswordlessOptions, _jsonSerializerOptions)</code>
-        
+
         <p>When self-hosting, make sure to mount a persistent volume to write your configuration. Read more <a href="https://docs.passwordless.dev/guide/self-hosting/configuration.html#volumes">here</a>.</p>
-        
-        <p>After doing this, you will need to restart the application, refresh this page and enter the Admin Email used here to receive a magic link.</p>
+
+        <p>After doing this, you will need to refresh this page and enter the Admin Email used here to receive a magic link.</p>
     }
 
 </Panel>
@@ -80,9 +80,9 @@
     public AdminConsoleCreateForm Form { get; set; } = new();
 
     public bool IsFormSubmitted { get; set; }
-    
+
     public string ProcessMessage { get; set; } = string.Empty;
-    
+
     public PasswordlessOptions? PasswordlessOptions { get; set; }
 
     protected override async Task OnInitializedAsync()
@@ -95,15 +95,14 @@
 
     private async Task OnAdminConsoleCreateFormSubmitted()
     {
-        
         IsFormSubmitted = true;
 
         Models.Organization organization;
         var now = TimeProvider.GetUtcNow().UtcDateTime;
 
-        CreateAppResultDto? appCreationResult = null;
-        
-        // create app in api
+        CreateAppResultDto? appCreationResult;
+
+        // Create app in the API
         try
         {
             using var http = new HttpClient();
@@ -117,7 +116,7 @@
             });
 
             response.EnsureSuccessStatusCode();
-            
+
             appCreationResult = (await response.Content.ReadFromJsonAsync<CreateAppResultDto>())!;
         }
         catch (Exception ex)
@@ -129,7 +128,7 @@
 
         await DbContext.Database.MigrateAsync();
 
-        // create org
+        // Create org
         try
         {
             organization = new Models.Organization
@@ -148,7 +147,7 @@
             return;
         }
 
-        // create admin
+        // Create admin
         try
         {
             var user = new ConsoleAdmin
@@ -208,7 +207,7 @@
 
         ProcessMessage = "✅ Admin Console has been initialized successfully.";
     }
-    
+
     public sealed class AdminConsoleCreateForm
     {
         [Required] public string AdminName { get; set; } = string.Empty;

--- a/src/AdminConsole/Components/Pages/Initialize.razor
+++ b/src/AdminConsole/Components/Pages/Initialize.razor
@@ -64,9 +64,8 @@
 
         <p>When self-hosting, make sure to mount a persistent volume to write your configuration. Read more <a href="https://docs.passwordless.dev/guide/self-hosting/configuration.html#volumes">here</a>.</p>
 
-        <p>After doing this, you will need to refresh this page and enter the Admin Email used here to receive a magic link.</p>
+        <p>After doing this, <a class="link-blue" href="/">navigate to the home page</a> and enter the Admin Email used here to receive a magic link.</p>
     }
-
 </Panel>
 
 @code {

--- a/src/AdminConsole/Db/ConsoleDbContext.cs
+++ b/src/AdminConsole/Db/ConsoleDbContext.cs
@@ -9,13 +9,9 @@ using Passwordless.AdminConsole.Models;
 
 namespace Passwordless.AdminConsole.Db;
 
-public class ConsoleDbContext : IdentityDbContext<ConsoleAdmin, IdentityRole, string>, IDataProtectionKeyContext
+public class ConsoleDbContext(DbContextOptions options)
+    : IdentityDbContext<ConsoleAdmin, IdentityRole, string>(options), IDataProtectionKeyContext
 {
-    public ConsoleDbContext(DbContextOptions options)
-        : base(options)
-    {
-    }
-
     public DbSet<Organization> Organizations { get; set; }
     public DbSet<Application> Applications { get; set; }
     public DbSet<Onboarding> Onboardings { get; set; }

--- a/src/AdminConsole/Db/DatabaseBootstrap.cs
+++ b/src/AdminConsole/Db/DatabaseBootstrap.cs
@@ -29,7 +29,7 @@ public static class DatabaseBootstrap
         }
 
         // if name starts with sqlite, use sqlite, else use mssql
-        if (!String.IsNullOrEmpty(sqlite))
+        if (!string.IsNullOrEmpty(sqlite))
         {
             ContextName = typeof(SqliteConsoleDbContext).FullName;
             builder.AddDatabaseContext<SqliteConsoleDbContext>((sp, o) =>
@@ -80,17 +80,25 @@ public static class DatabaseBootstrap
             {
                 var managementOptions = builder.Configuration.GetSection("PasswordlessManagement").Get<PasswordlessManagementOptions>();
                 var options = builder.Configuration.GetSection("Passwordless").Get<PasswordlessOptions>();
+                if (options is null)
+                {
+                    throw new ConfigurationErrorsException(
+                        "Missing 'Passwordless' options in application configuration."
+                    );
+                }
+
                 o.ApiSecret = options.ApiSecret;
                 o.ApiKey = options.ApiKey;
                 o.ApiUrl = options.ApiUrl;
 
                 if (builder.Configuration.GetValue("SelfHosted", false))
                 {
-                    // This will overwrite ApiUrl with the internal url for self-hosting, this is intentional.
+                    // This will overwrite ApiUrl with the internal URL for self-hosting, this is intentional.
                     if (string.IsNullOrEmpty(managementOptions.InternalApiUrl))
                     {
                         throw new ConfigurationErrorsException("Missing 'PasswordlessManagement:InternalApiUrl'.");
                     }
+
                     o.ApiUrl = managementOptions.InternalApiUrl;
                 }
             });

--- a/src/AdminConsole/Services/IScopedPasswordlessClient.cs
+++ b/src/AdminConsole/Services/IScopedPasswordlessClient.cs
@@ -1,0 +1,42 @@
+using Passwordless.AdminConsole.EventLog.DTOs;
+using Passwordless.Common.Models.Apps;
+using Passwordless.Common.Models.Authenticators;
+using Passwordless.Common.Models.Reporting;
+
+namespace Passwordless.AdminConsole.Services;
+
+public interface IScopedPasswordlessClient : IPasswordlessClient
+{
+    Task<ApplicationEventLogResponse> GetApplicationEventLog(int pageNumber, int pageSize);
+    Task<IEnumerable<PeriodicCredentialReportResponse>> GetPeriodicCredentialReportsAsync(PeriodicCredentialReportRequest request);
+    Task<IEnumerable<PeriodicActiveUserReportResponse>> GetPeriodicActiveUserReportsAsync(PeriodicActiveUserReportRequest request);
+
+    /// <summary>
+    /// Returns a list of configured authenticators for the current app. If the list is empty, all authenticators are allowed.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <returns></returns>
+    Task<IEnumerable<ConfiguredAuthenticatorResponse>> GetConfiguredAuthenticatorsAsync(ConfiguredAuthenticatorRequest request);
+
+    /// <summary>
+    /// Add specified authenticators to the whitelist/blacklist.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <returns></returns>
+    Task AddAuthenticatorsAsync(AddAuthenticatorsRequest request);
+
+    /// <summary>
+    /// Remove specified authenticators from the whitelist/blacklist.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <returns></returns>
+    Task RemoveAuthenticatorsAsync(RemoveAuthenticatorsRequest request);
+
+    Task SetFeaturesAsync(SetFeaturesRequest request);
+
+    Task<GetAuthenticationConfigurationsResult> GetAuthenticationConfigurationsAsync();
+    Task<GetAuthenticationConfigurationsResult> GetAuthenticationConfigurationAsync(string purpose);
+    Task CreateAuthenticationConfigurationAsync(SetAuthenticationConfigurationRequest configuration);
+    Task SaveAuthenticationConfigurationAsync(SetAuthenticationConfigurationRequest configuration);
+    Task DeleteAuthenticationConfigurationAsync(DeleteAuthenticationConfigurationRequest purpose);
+}

--- a/src/AdminConsole/Services/ScopedPasswordlessClient.cs
+++ b/src/AdminConsole/Services/ScopedPasswordlessClient.cs
@@ -9,42 +9,6 @@ using Passwordless.Common.Models.Reporting;
 
 namespace Passwordless.AdminConsole.Services;
 
-public interface IScopedPasswordlessClient : IPasswordlessClient
-{
-    Task<ApplicationEventLogResponse> GetApplicationEventLog(int pageNumber, int pageSize);
-    Task<IEnumerable<PeriodicCredentialReportResponse>> GetPeriodicCredentialReportsAsync(PeriodicCredentialReportRequest request);
-    Task<IEnumerable<PeriodicActiveUserReportResponse>> GetPeriodicActiveUserReportsAsync(PeriodicActiveUserReportRequest request);
-
-    /// <summary>
-    /// Returns a list of configured authenticators for the current app. If the list is empty, all authenticators are allowed.
-    /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
-    Task<IEnumerable<ConfiguredAuthenticatorResponse>> GetConfiguredAuthenticatorsAsync(ConfiguredAuthenticatorRequest request);
-
-    /// <summary>
-    /// Add specified authenticators to the whitelist/blacklist.
-    /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
-    Task AddAuthenticatorsAsync(AddAuthenticatorsRequest request);
-
-    /// <summary>
-    /// Remove specified authenticators from the whitelist/blacklist.
-    /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
-    Task RemoveAuthenticatorsAsync(RemoveAuthenticatorsRequest request);
-
-    Task SetFeaturesAsync(SetFeaturesRequest request);
-
-    Task<GetAuthenticationConfigurationsResult> GetAuthenticationConfigurationsAsync();
-    Task<GetAuthenticationConfigurationsResult> GetAuthenticationConfigurationAsync(string purpose);
-    Task CreateAuthenticationConfigurationAsync(SetAuthenticationConfigurationRequest configuration);
-    Task SaveAuthenticationConfigurationAsync(SetAuthenticationConfigurationRequest configuration);
-    Task DeleteAuthenticationConfigurationAsync(DeleteAuthenticationConfigurationRequest purpose);
-}
-
 public class ScopedPasswordlessClient : PasswordlessClient, IScopedPasswordlessClient
 {
     private readonly HttpClient _client;
@@ -135,7 +99,7 @@ public class ScopedPasswordlessClient : PasswordlessClient, IScopedPasswordlessC
 
     public async Task SetFeaturesAsync(SetFeaturesRequest request)
     {
-        using var response = await _client.PostAsJsonAsync($"/apps/features", request);
+        using var response = await _client.PostAsJsonAsync("/apps/features", request);
         response.EnsureSuccessStatusCode();
     }
 

--- a/src/AdminConsole/Services/SetupService.cs
+++ b/src/AdminConsole/Services/SetupService.cs
@@ -9,7 +9,7 @@ public class SetupService : ISetupService
     private readonly bool _isSelfHosted;
 
     public SetupService(
-        IOptions<PasswordlessOptions> options,
+        IOptionsSnapshot<PasswordlessOptions> options,
         IConfiguration configuration)
     {
         _options = options.Value;

--- a/src/AdminConsole/Services/SetupService.cs
+++ b/src/AdminConsole/Services/SetupService.cs
@@ -1,18 +1,17 @@
-using Microsoft.Extensions.Options;
 using Passwordless.Common.Configuration;
 
 namespace Passwordless.AdminConsole.Services;
 
 public class SetupService : ISetupService
 {
-    private readonly PasswordlessOptions _options;
+    private readonly PasswordlessOptions? _options;
     private readonly bool _isSelfHosted;
 
     public SetupService(
-        IOptionsSnapshot<PasswordlessOptions> options,
         IConfiguration configuration)
     {
-        _options = options.Value;
+        // Get the Passwordless options manually to skip the built-in validations in the Passwordless SDK
+        _options = configuration.GetSection("Passwordless").Get<PasswordlessOptions>();
         _isSelfHosted = configuration.IsSelfHosted();
     }
 
@@ -22,14 +21,15 @@ public class SetupService : ISetupService
         if (_isSelfHosted)
         {
             return Task.FromResult(
-                !(_options.ApiKey!.Contains("replaceme") || _options.ApiSecret.Contains("replaceme"))
+                !(_options?.ApiKey?.Contains("replaceme") == true ||
+                  _options?.ApiSecret.Contains("replaceme") == true)
             );
         }
         // Local and cloud -> check if API Secret has been set
         else
         {
             return Task.FromResult(
-                !string.IsNullOrWhiteSpace(_options.ApiSecret)
+                !string.IsNullOrWhiteSpace(_options?.ApiSecret)
             );
         }
     }

--- a/src/Api/Helpers/FriendlyExceptionsMiddleware.cs
+++ b/src/Api/Helpers/FriendlyExceptionsMiddleware.cs
@@ -27,7 +27,7 @@ public class FriendlyExceptionsMiddleware
 
     private async Task SafeNextAsync(HttpContext context)
     {
-        var env = context.RequestServices.GetService<IWebHostEnvironment>();
+        var env = context.RequestServices.GetRequiredService<IWebHostEnvironment>();
 
         try
         {


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes https://bitwarden.atlassian.net/browse/PAS-386

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

Currently, Admin Console asks the user to restart the app after completing the initialization. This PR makes it unnecessary by tuning the order in which the services/options are initialized and making use of the `reloadOnChange` feature in `Microsoft.Extensions.Configuration`.

### Shape

- Don't initialize the Passwordless SDK if the credentials are missing. Previously it was initialized with fake, non-working credentials as a work-around.
- Don't require the Passwordless client in code paths used during initialization. This allows the Admin Console to perform initialization even if the `Passwordless:` section is not configured.
- Fetch the Passwordless options in `SetupService` in a way that's not dependent on the initialization of the Passwordless SDK. The SDK does not allow the options to contain a `null` or empty `ApiSecret`. In `SetupService` this is a valid scenario, which indicates that the initialization has not been completed yet.
- Update the text on the page to instruct the user what to do after updating the configuration file.

### Screenshots

Step by step:

<img width="1130" alt="2024-07-04 18_36_01-localhost_8001_initialize" src="https://github.com/bitwarden/passwordless-server/assets/1935960/e37c6bad-9d59-41e5-83e4-f384456d5c86">

<img width="1123" alt="2024-07-04 18_37_47-localhost_8001_initialize" src="https://github.com/bitwarden/passwordless-server/assets/1935960/db3a52d1-0cc3-4f42-887c-bedf6a51209c">

<img width="509" alt="2024-07-04 18_38_02-PasswordlessServer – appsettings Development json" src="https://github.com/bitwarden/passwordless-server/assets/1935960/757fd0b7-5cf1-40ca-b808-526eb7e5a7b3">

<img width="832" alt="2024-07-04 18_38_12-Home page - Admin Console - Bitwarden Passwordless dev" src="https://github.com/bitwarden/passwordless-server/assets/1935960/bb912cc6-a253-4995-9df3-2b91f6b7ce63">

### Checklist

I did the following to ensure that my changes were tested thoroughly:
- Ran the initialization flow locally

I did the following to ensure that my changes do not introduce security vulnerabilities:
- Did not find any new vectors
