### PR TITLE
PAS-532-better-error-handling-auth-configs

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/AuthenticationConfiguration.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/AuthenticationConfiguration.razor
@@ -7,7 +7,7 @@
 @inject NavigationManager NavigationManager;
 @inject IHttpContextAccessor HttpContextAccessor;
 @inject IScopedPasswordlessClient Passwordless;
-@inject Logger<AuthenticationConfiguration> Logger;
+@inject ILogger<AuthenticationConfiguration> Logger;
 
 @if (!CurrentContext.IsPendingDelete)
 {

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/AuthenticationConfiguration.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/AuthenticationConfiguration.razor
@@ -7,6 +7,7 @@
 @inject NavigationManager NavigationManager;
 @inject IHttpContextAccessor HttpContextAccessor;
 @inject IScopedPasswordlessClient Passwordless;
+@inject Logger<AuthenticationConfiguration> Logger;
 
 @if (!CurrentContext.IsPendingDelete)
 {
@@ -102,7 +103,21 @@
             }
         }
 
-        Configurations = (await Passwordless.GetAuthenticationConfigurationsAsync()).Configurations.Select(GetEntry).ToImmutableArray();
+        Configurations = await GetConfigurations();
+    }
+
+
+    private async Task<IReadOnlyCollection<AuthenticationConfigurationEntry>> GetConfigurations()
+    {
+        try
+        {
+            return (await Passwordless.GetAuthenticationConfigurationsAsync()).Configurations.Select(GetEntry).ToImmutableArray();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex , "Failed to retrieve authentication configurations");
+            return Array.Empty<AuthenticationConfigurationEntry>();
+        }
     }
 
     public async Task OnSelectedFormConfirmed()

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/AuthenticationConfiguration.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/AuthenticationConfiguration.razor
@@ -12,7 +12,7 @@
 @if (!CurrentContext.IsPendingDelete)
 {
     <Panel Header="Authentication Configuration">
-        <p>List of configurations for your authentication tokens. Read more in the <a class="link-blue underline" href="https://docs.passwordless.dev/guide/admin-console/applications.html#authentiation-configurations" target="_blank">docs</a></p>
+        <p>List of configurations for your authentication tokens. Read more in the <a class="link-blue underline" href="https://docs.passwordless.dev/guide/admin-console/applications.html#authentication-configurations" target="_blank">docs</a></p>
 
         <div>
             <a class="btn-primary" href="/app/@(AppId)/settings/authentication-configuration/new">Add New Authentication Configuration</a>


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-532](https://bitwarden.atlassian.net/browse/PAS-532)


### Description
When failing to pull the auth configs, it errored and failed to load the page. This will put a try catch that will log the error and return an empty array on failure.

### Shape
Added a try catch around getting the auth configs.

### Screenshots
<img width="1132" alt="image" src="https://github.com/bitwarden/passwordless-server/assets/7258973/d18e9f27-4b07-455b-af0f-d0323e47a604">


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Able to get auth configs without an issue

I did the following to ensure that my changes do not introduce security vulnerabilities:
- No new paths added


[PAS-532]: https://bitwarden.atlassian.net/browse/PAS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ