### PR TITLE
PAS-479 | Repair plan section lifecycle when api keys are (un)locked

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/FeatureListItemIcon.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/FeatureListItemIcon.razor
@@ -1,0 +1,14 @@
+<svg class="@Class" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+</svg>
+
+@code {
+    private const string BaseClass = "text-blue-400";
+
+    private string Class => AdditionalAttributes.ContainsKey("class")
+        ? $"{BaseClass} {AdditionalAttributes["class"]}"
+        : BaseClass;
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IDictionary<string, object> AdditionalAttributes { get; set; } = new Dictionary<string, object>(0);
+}

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/PlanSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/PlanSection.razor
@@ -1,0 +1,157 @@
+@using System.Collections.Immutable
+@using System.ComponentModel.DataAnnotations
+@using Microsoft.Extensions.Options
+@using Passwordless.AdminConsole.Billing.Configuration
+@using Passwordless.AdminConsole.Helpers
+
+@inject ISharedBillingService BillingService;
+@inject ICurrentContext CurrentContext;
+@inject IOptionsSnapshot<BillingOptions> BillingOptions;
+@inject NavigationManager NavigationManager;
+@inject IHttpContextAccessor HttpContextAccessor;
+
+<Panel Header="Plan">
+    <p>The plan you select for this app changes the pricing and features available.</p>
+    <div class="gap-4 grid sm:grid-cols-1 md:grid-cols-3">
+        @foreach (var plan in Plans)
+        {
+            <div class="@(plan.IsActive ? "pricing-card-active" : "pricing-card")">
+                <div class="flex flex-wrap items-center justify-center">
+                    @if (plan.IsActive)
+                    {
+                        if (plan.IsOutdated)
+                        {
+                            <Badge Variant="@ContextualStyles.Warning" Message="New Available"/>
+                        }
+                        else
+                        {
+                            <Badge Variant="@ContextualStyles.Primary" Message="Active"/>
+                        }
+                    }
+                    else
+                    {
+                        <Badge Class="invisible" Message="Hidden"/>
+                    }
+                </div>
+                <h3 class="text-center">@plan.Label</h3>
+                <div class="space-y-0">
+                    <p class="text-lg font-black text-center">@plan.Price</p>
+                    <p class="text-sm text-gray-600 text-center">per user per month@(!string.IsNullOrEmpty(plan.PriceHint) ? "*" : string.Empty)</p>
+                </div>
+                <div class="flex-1">
+                    <ul class="mt-4 space-y-2">
+                        @foreach (var feature in plan.Features)
+                        {
+                            <li class="flex items-start">
+                                <FeatureListItemIcon class="flex-shrink-0 w-5 h-5 mr-2" />
+                                @feature
+                            </li>
+                        }
+                    </ul>
+                </div>
+                @if (!string.IsNullOrEmpty(plan.PriceId))
+                {
+                    <div class="mt-auto text-center space-y-4">
+                        @if (!string.IsNullOrEmpty(plan.PriceHint))
+                        {
+                            <p class="text-xs text-gray-600 text-center">* @(plan.PriceHint)</p>
+                        }
+                        @if (plan.CanSubscribe)
+                        {
+                            <EditForm FormName="@SubscribePlanFormName" Model="@SubscribePlanForm" OnValidSubmit="@OnSubscribePlanFormSubmittedAsync">
+                                <DataAnnotationsValidator />
+                                <input type="hidden" name="SubscribePlanForm.SelectedPlan" value="@plan.Value"/>
+                                <button class="btn-primary" type="submit">Subscribe</button>
+                            </EditForm>
+                        }
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</Panel>
+
+@code {
+    public const string SubscribePlanFormName = "subscribe-plan-form";
+    
+    public ICollection<PlanModel> Plans { get; } = new List<PlanModel>();
+
+    [SupplyParameterFromForm(FormName = SubscribePlanFormName)]
+    public SubscribeFormModel SubscribePlanForm { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!CurrentContext.Organization!.HasSubscription)
+        {
+            AddPlan(BillingOptions.Value.Store.Free);
+        }
+
+        AddPlan(BillingOptions.Value.Store.Pro);
+        AddPlan(BillingOptions.Value.Store.Enterprise);
+        
+        if (HttpContextAccessor.IsRazorPages() && HttpContextAccessor.HttpContext!.Request.HasFormContentType)
+        {
+            var request = HttpContextAccessor.HttpContext!.Request;
+            switch (request.Form["_handler"])
+            {
+                case SubscribePlanFormName:
+                    SubscribePlanForm.SelectedPlan = request.Form[$"{nameof(SubscribePlanForm)}.{nameof(SubscribePlanForm.SelectedPlan)}"].ToString();
+                    await OnSubscribePlanFormSubmittedAsync();
+                    break;
+            }
+        }
+    }
+
+    private void AddPlan(string plan)
+    {
+        var options = BillingOptions.Value.Plans[plan];
+        var isActive = CurrentContext.BillingPlan == plan;
+        var isOutdated = isActive && CurrentContext.BillingPriceId != options.PriceId;
+
+        bool canSubscribe;
+        if (plan == BillingOptions.Value.Store.Free || CurrentContext.IsPendingDelete)
+        {
+            canSubscribe = false;
+        }
+        else
+        {
+            canSubscribe = CurrentContext.BillingPriceId != options.PriceId;
+        }
+
+        var model = new PlanModel(
+            plan,
+            options.PriceId,
+            options.Ui.Label,
+            options.Ui.Price,
+            options.Ui.PriceHint,
+            options.Ui.Features.ToImmutableList(),
+            isActive,
+            canSubscribe,
+            isOutdated);
+        Plans.Add(model);
+    }
+
+    public record PlanModel(
+        string Value,
+        string? PriceId,
+        string Label,
+        string Price,
+        string? PriceHint,
+        IReadOnlyCollection<string> Features,
+        bool IsActive,
+        bool CanSubscribe,
+        bool IsOutdated);
+
+    public class SubscribeFormModel
+    {
+        [Required]
+        public string SelectedPlan { get; set; }
+    }
+
+    private async Task OnSubscribePlanFormSubmittedAsync()
+    {
+        var appId = CurrentContext.AppId!;
+        var redirectUrl = await BillingService.ChangePlanAsync(appId, SubscribePlanForm.SelectedPlan);
+        NavigationManager.NavigateTo(redirectUrl!);
+    }
+}

--- a/src/AdminConsole/Middleware/CurrentContext.cs
+++ b/src/AdminConsole/Middleware/CurrentContext.cs
@@ -12,6 +12,8 @@ public class CurrentContext : ICurrentContext
 
     public string? ApiKey { get; private set; }
     public bool IsPendingDelete { get; private set; }
+    public string BillingPlan { get; private set; }
+    public string? BillingPriceId { get; private set; }
     public ApplicationFeatureContext Features { get; private set; }
     public Organization? Organization { get; private set; }
     public int? OrgId { get; private set; }
@@ -24,6 +26,8 @@ public class CurrentContext : ICurrentContext
         ApiSecret = application.ApiSecret;
         ApiKey = application.ApiKey;
         IsPendingDelete = application.DeleteAt.HasValue;
+        BillingPlan = application.BillingPlan;
+        BillingPriceId = application.BillingPriceId;
     }
 
     public void SetFeatures(ApplicationFeatureContext context)

--- a/src/AdminConsole/Middleware/ICurrentContext.cs
+++ b/src/AdminConsole/Middleware/ICurrentContext.cs
@@ -14,6 +14,8 @@ public interface ICurrentContext
     string? ApiSecret { get; }
     string? ApiKey { get; }
     bool IsPendingDelete { get; }
+    string BillingPlan { get; }
+    string? BillingPriceId { get; }
     ApplicationFeatureContext Features { get; }
     Organization? Organization { get; }
     int? OrgId { get; }

--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml
@@ -1,68 +1,12 @@
 ﻿@page "/settings"
-@using Badge = Passwordless.AdminConsole.Components.Shared.Badge
 @using Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents
-@using Passwordless.AdminConsole.Components.Pages.App.Settings
 @model SettingsModel
-@inject IWebHostEnvironment Environment
 
 @{
     ViewData["Title"] = "Settings";
 }
 
-<div class="panel">
-    <h2>Plan</h2>
-    <p>The plan you select for this app changes the pricing and features available.</p>
-    <div class="gap-4 grid sm:grid-cols-1 md:grid-cols-3">
-        @foreach (var plan in Model.Plans)
-        {
-            <div class="@(plan.IsActive ? "pricing-card-active" : "pricing-card")">
-                <div class="flex flex-wrap items-center justify-center">
-                    @if (plan.IsActive)
-                    {
-                        if (plan.IsOutdated)
-                        {
-                            <component type="typeof(Badge)" render-mode="Static" param-Variant="@(ContextualStyles.Warning)" param-Message="@("New Available")" />
-                        }
-                        else
-                        {
-                            <component type="typeof(Badge)" render-mode="Static" param-Variant="@(ContextualStyles.Primary)" param-Message="@("Active")" />
-                        }
-                    }
-                    else
-                    {
-                        <component type="typeof(Badge)" render-mode="Static" param-Class="@("invisible")" param-Message="@("Hidden")" />
-                    }
-                </div>
-                <h3 class="text-center">@plan.Label</h3>
-                <div class="space-y-0">
-                    <p class="text-lg font-black text-center">@plan.Price</p>
-                    <p class="text-sm text-gray-600 text-center">per user per month@(!string.IsNullOrEmpty(plan.PriceHint) ? "*" : string.Empty)</p>
-                </div>
-                <div class="flex-1">
-                    <ul class="mt-4 space-y-2">
-                        @foreach (var feature in plan.Features)
-                        {
-                            <li class="flex items-start">
-                                <feature-list-item-icon class="flex-shrink-0 w-5 h-5 mr-2"></feature-list-item-icon>
-                                @feature
-                            </li>
-                        }
-                    </ul>
-                </div>
-                <div asp-if="!string.IsNullOrEmpty(plan.PriceId)" class="mt-auto text-center space-y-4">
-                    <p asp-if="!string.IsNullOrEmpty(plan.PriceHint)" class="text-xs text-gray-600 text-center">* @(plan.PriceHint)</p>
-                    @if (plan.CanSubscribe)
-                    {
-                        <form method="post" asp-page-handler="Cancel">
-                            <input type="hidden" name="selectedPlan" value="@plan.Value"/>
-                            <button asp-page-handler="ChangePlan" type="submit" class="btn-primary">Subscribe</button>
-                        </form>
-                    }
-                </div>
-            </div>
-        }
-    </div>
-</div>
+<component type="typeof(PlanSection)" render-mode="Static" />
 
 <component type="typeof(ApiKeysSection)" render-mode="Static" />
 


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-479](https://bitwarden.atlassian.net/browse/PAS-479)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

When API keys or API secrets are locked or unlocked, the plan section fails to initialize and fails to render as a result. This pull request will repair the lifecycle indefinitely as more sections & forms are added to the application settings pages.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots

https://github.com/user-attachments/assets/13567947-4a78-4718-921b-8d66e7430a38

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-479]: https://bitwarden.atlassian.net/browse/PAS-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ