### PR TITLE
PAS-479 | Fix magic links section lifecycle when locking/unlocking API keys

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor
@@ -13,7 +13,8 @@
      </p>
      <div>
          <label for="IsMagicLinksEnabled">
-             <InputCheckbox id="IsMagicLinksEnabled" class="mr-1 my-4" @bind-Value="Form!.IsEnabled" />
+             <input type="hidden" name="Form.IsEnabled" value="false" />
+             <InputCheckbox id="IsMagicLinksEnabled" class="mr-1 my-4" @bind-Value="Form!.IsEnabled"/>
              Enable Magic Links
          </label>
      </div>

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor
@@ -1,0 +1,22 @@
+@inject ICurrentContext CurrentContext;
+@inject IHttpContextAccessor HttpContextAccessor;
+@inject IScopedPasswordlessClient ScopedPasswordlessClient;
+@inject NavigationManager NavigationManager;
+@inject ILogger<MagicLinksSection> Logger;
+
+<Panel Header="Magic Links">
+ <EditForm FormName="@FormName" Model="@Form" OnSubmit="@OnFormSubmittedAsync">
+     <p>
+         Magic Links provide a secure and user-friendly way to authenticate users in applications. While onboarding new
+         users into your application or in the event of account recovery, a Magic Link can be sent via email to gain access
+         to the system. This removes the friction of verifying users and resetting passkeys, enhancing the user experience.
+     </p>
+     <div>
+         <label for="IsMagicLinksEnabled">
+             <InputCheckbox id="IsMagicLinksEnabled" class="mr-1 my-4" @bind-Value="Form!.IsEnabled" />
+             Enable Magic Links
+         </label>
+     </div>
+     <button id="save-magic-links-btn" class="btn-primary" type="submit">Save</button>
+ </EditForm>
+</Panel>

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor.cs
@@ -1,0 +1,51 @@
+using System.Web;
+using Microsoft.AspNetCore.Components;
+using Passwordless.Common.Models.Apps;
+
+namespace Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents;
+
+public partial class MagicLinksSection : ComponentBase
+{
+    public const string FormName = "magic-links-form";
+
+    [SupplyParameterFromForm(FormName = FormName)]
+    public SaveFormModel? Form { get; set; }
+
+    public class SaveFormModel
+    {
+        public bool IsEnabled { get; set; }
+    }
+
+    protected override void OnInitialized()
+    {
+        Form ??= new SaveFormModel { IsEnabled = CurrentContext.Features.IsMagicLinksEnabled };
+    }
+
+    private async Task OnFormSubmittedAsync()
+    {
+        static bool? GetFinalValue(bool originalValue, bool postedValue) =>
+            originalValue == postedValue ? null : postedValue;
+
+        var name = HttpContextAccessor.HttpContext!.User.Identity!.Name;
+        if (string.IsNullOrWhiteSpace(CurrentContext.AppId) || string.IsNullOrWhiteSpace(name))
+        {
+            NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode("Something unexpected happened.")}");
+            return;
+        }
+
+        try
+        {
+            await ScopedPasswordlessClient.SetFeaturesAsync(new SetFeaturesRequest
+            {
+                PerformedBy = name,
+                EnableMagicLinks = GetFinalValue(CurrentContext.Features.IsMagicLinksEnabled, Form.IsEnabled)
+            });
+            NavigationManager.Refresh();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save settings for {appId}", CurrentContext.AppId);
+            NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode(ex.Message)}");
+        }
+    }
+}

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/MagicLinksSection.razor.cs
@@ -1,5 +1,6 @@
 using System.Web;
 using Microsoft.AspNetCore.Components;
+using Passwordless.AdminConsole.Helpers;
 using Passwordless.Common.Models.Apps;
 
 namespace Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents;
@@ -16,9 +17,22 @@ public partial class MagicLinksSection : ComponentBase
         public bool IsEnabled { get; set; }
     }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         Form ??= new SaveFormModel { IsEnabled = CurrentContext.Features.IsMagicLinksEnabled };
+
+        // If we've posted a form, we need to add backwards compatibility for Razor Pages. Bind it to the model, and trigger the form submission handler.
+        if (HttpContextAccessor.IsRazorPages() && HttpContextAccessor.HttpContext!.Request.HasFormContentType)
+        {
+            var request = HttpContextAccessor.HttpContext!.Request;
+            switch (request.Form["_handler"])
+            {
+                case FormName:
+                    Form.IsEnabled = bool.Parse(request.Form["Form.IsEnabled"]!);
+                    await OnFormSubmittedAsync();
+                    break;
+            }
+        }
     }
 
     private async Task OnFormSubmittedAsync()

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor
@@ -13,7 +13,8 @@
         </p>
         <div>
             <label for="IsManualTokenGenerationEnabled">
-                <InputCheckbox id="IsManualTokenGenerationEnabled" class="mr-1 my-4" @bind-Value="Form!.IsEnabled" />
+                <input type="hidden" name="Form.IsEnabled" value="false" />
+                <InputCheckbox id="IsManualTokenGenerationEnabled" class="mr-1 my-4" @bind-Value="Form!.IsEnabled"/>
                 Enable Manually Generated Verification Tokens
             </label>
         </div>

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor
@@ -1,0 +1,26 @@
+@inject ICurrentContext CurrentContext;
+@inject IHttpContextAccessor HttpContextAccessor;
+@inject IScopedPasswordlessClient ScopedPasswordlessClient;
+@inject NavigationManager NavigationManager;
+@inject ILogger<MagicLinksSection> Logger;
+
+<Panel Header="Manually Generated Authentication Tokens">
+    <EditForm FormName="@FormName" Model="@Form" OnSubmit="@OnFormSubmittedAsync">
+        <p>
+            Manually generated verification tokens have many uses in authentication. A primary use would be issuing a "magic link" for a
+            user to log-in to their account in the event they've misplaced their passkey. Once the identity of the user has been
+            verified, you can send them a hyperlink that contains the token issued by <code>signin/generate-token</code>.
+        </p>
+        <div>
+            <label for="IsManualTokenGenerationEnabled">
+                <InputCheckbox id="IsManualTokenGenerationEnabled" class="mr-1 my-4" @bind-Value="Form!.IsEnabled" />
+                Enable Manually Generated Verification Tokens
+            </label>
+        </div>
+        <button id="save-manually-generated-authentication-tokens-btn" class="btn-primary" type="submit">Save</button>
+    </EditForm>
+</Panel>
+
+@code {
+    
+}

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor.cs
@@ -1,0 +1,50 @@
+using System.Web;
+using Microsoft.AspNetCore.Components;
+using Passwordless.Common.Models.Apps;
+
+namespace Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents;
+
+public partial class ManuallyGeneratedAuthenticationTokensSection : ComponentBase
+{
+    public const string FormName = "manually-generated-authentication-tokens-form";
+
+    public SaveFormModel? Form { get; set; }
+
+    protected override void OnInitialized()
+    {
+        Form ??= new SaveFormModel { IsEnabled = CurrentContext.Features.IsGenerateSignInTokenEndpointEnabled };
+    }
+
+    private async Task OnFormSubmittedAsync()
+    {
+        static bool? GetFinalValue(bool originalValue, bool postedValue) =>
+            originalValue == postedValue ? null : postedValue;
+
+        var name = HttpContextAccessor.HttpContext!.User.Identity!.Name;
+        if (string.IsNullOrWhiteSpace(CurrentContext.AppId) || string.IsNullOrWhiteSpace(name))
+        {
+            NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode("Something unexpected happened.")}");
+            return;
+        }
+
+        try
+        {
+            await ScopedPasswordlessClient.SetFeaturesAsync(new SetFeaturesRequest
+            {
+                PerformedBy = name,
+                EnableManuallyGeneratedAuthenticationTokens = GetFinalValue(CurrentContext.Features.IsGenerateSignInTokenEndpointEnabled, Form!.IsEnabled)
+            });
+            NavigationManager.Refresh();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save settings for {appId}", CurrentContext.AppId);
+            NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode(ex.Message)}");
+        }
+    }
+
+    public class SaveFormModel
+    {
+        public bool IsEnabled { get; set; }
+    }
+}

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/ManuallyGeneratedAuthenticationTokensSection.razor.cs
@@ -1,5 +1,6 @@
 using System.Web;
 using Microsoft.AspNetCore.Components;
+using Passwordless.AdminConsole.Helpers;
 using Passwordless.Common.Models.Apps;
 
 namespace Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents;
@@ -10,9 +11,22 @@ public partial class ManuallyGeneratedAuthenticationTokensSection : ComponentBas
 
     public SaveFormModel? Form { get; set; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         Form ??= new SaveFormModel { IsEnabled = CurrentContext.Features.IsGenerateSignInTokenEndpointEnabled };
+
+        // If we've posted a form, we need to add backwards compatibility for Razor Pages. Bind it to the model, and trigger the form submission handler.
+        if (HttpContextAccessor.IsRazorPages() && HttpContextAccessor.HttpContext!.Request.HasFormContentType)
+        {
+            var request = HttpContextAccessor.HttpContext!.Request;
+            switch (request.Form["_handler"])
+            {
+                case FormName:
+                    Form.IsEnabled = bool.Parse(request.Form["Form.IsEnabled"]!);
+                    await OnFormSubmittedAsync();
+                    break;
+            }
+        }
     }
 
     private async Task OnFormSubmittedAsync()

--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml
@@ -66,33 +66,9 @@
 
 <component type="typeof(ApiKeysSection)" render-mode="Static" />
 
-<div class="panel">
-    <form method="post" asp-page-handler="Settings">
-        <h2>Manually Generated Verification Tokens</h2>
-        <p class="mt-3">
-            Manually generated verification tokens have many uses in authentication. A primary use would be issuing a "magic link" for a
-            user to log-in to their account in the event they've misplaced their passkey. Once the identity of the user has been
-            verified, you can send them a hyperlink that contains the token issued by <code>signin/generate-token</code>.
-        </p>
-        <label asp-for="IsManualTokenGenerationEnabled">
-            <input class="mr-1 my-4" type="checkbox" asp-for="IsManualTokenGenerationEnabled"/>
-            Enable Manually Generated Verification Tokens
-        </label>
-        <br>
-        <h2>Magic Links</h2>
-        <p class="mt-3">
-            Magic Links provide a secure and user-friendly way to authenticate users in applications. While onboarding new
-            users into your application or in the event of account recovery, a Magic Link can be sent via email to gain access
-            to the system. This removes the friction of verifying users and resetting passkeys, enhancing the user experience.
-        </p>
-        <label asp-for="IsMagicLinksEnabled">
-            <input class="mr-1 my-4" type="checkbox" asp-for="IsMagicLinksEnabled"/>
-            Enable Magic Links
-        </label>
-        <br>
-        <button id="btn-save-settings" class="btn-primary" type="submit">Save</button>
-    </form>
-</div>
+<component type="typeof(MagicLinksSection)" render-mode="Static" />
+
+<component type="typeof(ManuallyGeneratedAuthenticationTokensSection)" render-mode="Static" />
 
 @if (Model.IsAttestationAllowed)
 {

--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Passwordless.AdminConsole.Middleware;
 using Passwordless.AdminConsole.Services;
-using Passwordless.Common.Models.Apps;
 using Application = Passwordless.AdminConsole.Models.Application;
 
 namespace Passwordless.AdminConsole.Pages.App.Settings;
@@ -13,20 +12,17 @@ public class SettingsModel : BaseExtendedPageModel
     private readonly IDataService _dataService;
     private readonly ICurrentContext _currentContext;
     private readonly IApplicationService _appService;
-    private readonly IScopedPasswordlessClient _scopedPasswordlessClient;
 
     public SettingsModel(
         ILogger<SettingsModel> logger,
         IDataService dataService,
         ICurrentContext currentContext,
-        IApplicationService appService,
-        IScopedPasswordlessClient scopedPasswordlessClient)
+        IApplicationService appService)
     {
         _logger = logger;
         _dataService = dataService;
         _currentContext = currentContext;
         _appService = appService;
-        _scopedPasswordlessClient = scopedPasswordlessClient;
     }
 
     public Models.Organization Organization { get; set; }
@@ -41,12 +37,6 @@ public class SettingsModel : BaseExtendedPageModel
 
     public bool CanDeleteImmediately { get; private set; }
 
-    [BindProperty]
-    public bool IsManualTokenGenerationEnabled { get; set; }
-
-    [BindProperty]
-    public bool IsMagicLinksEnabled { get; set; }
-
     private async Task InitializeAsync()
     {
         Organization = await _dataService.GetOrganizationWithDataAsync();
@@ -56,9 +46,6 @@ public class SettingsModel : BaseExtendedPageModel
 
         Application = application ?? throw new InvalidOperationException("Application not found.");
         CanDeleteImmediately = await _appService.CanDeleteApplicationImmediatelyAsync(ApplicationId);
-
-        IsManualTokenGenerationEnabled = _currentContext.Features.IsGenerateSignInTokenEndpointEnabled;
-        IsMagicLinksEnabled = _currentContext.Features.IsMagicLinksEnabled;
     }
 
     public async Task OnGet()

--- a/src/AdminConsole/Pages/App/Settings/Settings.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Settings/Settings.cshtml.cs
@@ -158,35 +158,6 @@ public class SettingsModel : BaseExtendedPageModel
         return Redirect(redirectUrl!);
     }
 
-    public async Task<IActionResult> OnPostSettingsAsync()
-    {
-        static bool? GetFinalValue(bool originalValue, bool postedValue) =>
-            originalValue == postedValue ? null : postedValue;
-
-        if (string.IsNullOrWhiteSpace(_currentContext.AppId) || string.IsNullOrWhiteSpace(User.Identity?.Name))
-        {
-            return RedirectToPage("/Error", new { Message = "Something unexpected happened." });
-        }
-
-        try
-        {
-            await _scopedPasswordlessClient.SetFeaturesAsync(new SetFeaturesRequest
-            {
-                PerformedBy = User.Identity!.Name,
-                EnableManuallyGeneratedAuthenticationTokens =
-                    GetFinalValue(_currentContext.Features.IsGenerateSignInTokenEndpointEnabled, IsManualTokenGenerationEnabled),
-                EnableMagicLinks = GetFinalValue(_currentContext.Features.IsMagicLinksEnabled, IsMagicLinksEnabled)
-            });
-
-            return RedirectToPage();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to save settings for {appId}", _currentContext.AppId);
-            return RedirectToPage("/Error", new { ex.Message });
-        }
-    }
-
     private void AddPlan(string plan)
     {
         var options = _billingOptions.Plans[plan];


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-479](https://bitwarden.atlassian.net/browse/PAS-479)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

Magic links section was broken when unlocking/locking API keys.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-479]: https://bitwarden.atlassian.net/browse/PAS-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ