### PR TITLE
(hold) PAS-541 | Handle certain situations where magic links are disabled.

### DIFF
--- a/src/AdminConsole/Components/Pages/Organization/Admins.razor.cs
+++ b/src/AdminConsole/Components/Pages/Organization/Admins.razor.cs
@@ -81,6 +81,12 @@ public partial class Admins : ComponentBase
             return;
         }
 
+        if (!CurrentContext.Organization!.IsMagicLinksEnabled)
+        {
+            DeleteActiveFormValidationMessageStore!.Add(() => DeleteActiveForm.UserId!, "Magic links are disabled. Temporarily enable magic links, and then delete the admin.");
+            return;
+        }
+
         var performedBy = ConsoleAdmins!.Single(x => x.Email == HttpContextAccessor.HttpContext!.User.GetEmail());
         EventLogger.LogDeleteAdminEvent(performedBy, user!, TimeProvider.GetUtcNow().UtcDateTime);
 

--- a/src/AdminConsole/Components/Shared/Credentials.razor
+++ b/src/AdminConsole/Components/Shared/Credentials.razor
@@ -67,13 +67,16 @@
                                     class="block mr-auto rounded py-1 text-xs font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600">
                                     Show less
                                 </button>
-                                <ConfirmButton ConfirmTitle="Delete credential"
-                                               ConfirmDescription="Are you sure you want to delete this credential?"
-                                               ConfirmButtonText="Delete"
-                                               name="DeleteCredentialForm.CredentialId"
-                                               type="submit"
-                                               value="@cred.DescriptorId"
-                                               class="block ml-auto rounded bg-red-600 py-1 px-2 text-xs font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600">Remove</ConfirmButton>
+                                @if (CanDelete)
+                                {
+                                    <ConfirmButton ConfirmTitle="Delete credential"
+                                                   ConfirmDescription="Are you sure you want to delete this credential?"
+                                                   ConfirmButtonText="Delete"
+                                                   name="DeleteCredentialForm.CredentialId"
+                                                   type="submit"
+                                                   value="@cred.DescriptorId"
+                                                   class="block ml-auto rounded bg-red-600 py-1 px-2 text-xs font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600">Remove</ConfirmButton>
+                                }
                             </ConfirmEditForm>
                         }
                     </div>

--- a/src/AdminConsole/Components/Shared/Credentials.razor.cs
+++ b/src/AdminConsole/Components/Shared/Credentials.razor.cs
@@ -43,6 +43,9 @@ public partial class Credentials : ComponentBase
     public bool HideDetails { get; set; }
 
     [Parameter]
+    public bool CanDelete { get; set; } = true;
+
+    [Parameter]
     public required IPasswordlessClient PasswordlessClient { get; set; }
 
     [Parameter]
@@ -70,6 +73,10 @@ public partial class Credentials : ComponentBase
 
     public async Task DeleteCredentialAsync()
     {
+        if (!CanDelete)
+        {
+            throw new InvalidOperationException("Deleting credentials is not allowed.");
+        }
         var validationContext = new ValidationContext(DeleteCredentialForm);
         var validationResult = Validator.TryValidateObject(DeleteCredentialForm, validationContext, null, true);
         if (!validationResult)

--- a/src/AdminConsole/Pages/Account/Profile.cshtml
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml
@@ -11,6 +11,7 @@
 
 <div class="panel">
     <h2>Passkeys</h2>   
-    <component type="typeof(Credentials)" render-mode="Static" param-HideDetails="@false" param-PasswordlessClient="@PasswordlessClient" param-UserId="@Model.UserId" />
+    <component type="typeof(Credentials)" render-mode="Static" param-HideDetails="@false" param-PasswordlessClient="@PasswordlessClient" param-UserId="@Model.UserId" param-CanDelete="@Model.CanDeleteCredentials" />
+    <component asp-if="!@Model.CanDeleteCredentials" type="typeof(Alert)" render-mode="Static" param-Style="@(ContextualStyles.Warning)" param-ChildContent="@(new RenderFragment(builder => { builder.AddContent(0, "Magic links are disabled for admins in this organization, you cannot delete credentials"); }))" />
     <partial name="Shared/_AddPasskeys"/>
 </div>

--- a/src/AdminConsole/Pages/Account/Profile.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/Profile.cshtml.cs
@@ -1,9 +1,19 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Passwordless.AdminConsole.Helpers;
+using Passwordless.AdminConsole.Middleware;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class Profile : PageModel
 {
+    private readonly ICurrentContext _currentContext;
+
+    public Profile(ICurrentContext currentContext)
+    {
+        _currentContext = currentContext;
+    }
+
     public string UserId => HttpContext.User.GetId();
+
+    public bool CanDeleteCredentials => _currentContext.Organization!.IsMagicLinksEnabled;
 }

--- a/src/AdminConsole/Pages/Account/UserOnboarding.cshtml
+++ b/src/AdminConsole/Pages/Account/UserOnboarding.cshtml
@@ -13,6 +13,7 @@
     <p class="v-cloak" v-if="!supportsPasskeys.value && supportsSecurityKeys.value">We noticed your device supports security keys, so if you have a yubikey you can use it to secure your account.</p>
     
     <component type="typeof(Credentials)" render-mode="Static" param-HideDetails="@(true)" param-PasswordlessClient="@(PasswordlessClient)" param-UserId="@Model.UserId" />
+    <component asp-if="!@Model.IsMagicLinksEnabled" type="typeof(Alert)" render-mode="Static" param-Style="@(ContextualStyles.Danger)" param-ChildContent="@(new RenderFragment(builder => { builder.AddContent(0, (MarkupString)"Magic links are disabled for admins in this organization. <strong>If you do not add passkeys, you will not be able to sign in again.</strong>"); }))" />
     <partial name="Shared/_AddPasskeys" />
 </div>
 

--- a/src/AdminConsole/Pages/Account/UserOnboarding.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/UserOnboarding.cshtml.cs
@@ -1,9 +1,21 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Passwordless.AdminConsole.Helpers;
+using Passwordless.AdminConsole.Middleware;
 
 namespace Passwordless.AdminConsole.Pages.Account;
 
 public class UserOnboarding : PageModel
 {
+    private readonly ICurrentContext _currentContext;
+
+    public UserOnboarding(ICurrentContext currentContext)
+    {
+        _currentContext = currentContext;
+    }
+
     public string UserId => HttpContext.User.GetId();
+
+    public bool CanDeleteCredentials => _currentContext.Organization!.IsMagicLinksEnabled;
+
+    public bool IsMagicLinksEnabled => _currentContext.Organization!.IsMagicLinksEnabled;
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-541](https://bitwarden.atlassian.net/browse/PAS-541)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

- Handle situation where we attempt to delete an admin when magic links are disabled. To avoid ending up in a situation where we could be left with admins without passkeys, we prevent deleting admins with magic links disabled and guide the admin in temporarily enabling magic links. When they attempt to disable magic links again, it will revalidate whether all admins have passkeys configured.
- Inviting a new admin will nudge him in adding passkeys when magic links are disabled. Alternatively, we could add middleware to prevent him from leaving the useronboarding page without passkeys configured.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-541]: https://bitwarden.atlassian.net/browse/PAS-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ