### PR TITLE
Fix Open API documentation spawning multiple ApiKey/ApiSecret fields

### DIFF
--- a/src/Api/Endpoints/AuthenticationConfiguration.cs
+++ b/src/Api/Endpoints/AuthenticationConfiguration.cs
@@ -14,7 +14,6 @@ public static class AuthenticationConfigurationEndpoints
     {
         var group = app.MapGroup("/auth-configs")
             .RequireCors("default")
-            .WithOpenApi()
             .WithTags(OpenApiTags.AuthConfigs);
 
         group.MapGet("/list", async (
@@ -29,6 +28,7 @@ public static class AuthenticationConfigurationEndpoints
                         .Select(dto => dto.ToResponse())
                 });
             })
+            .WithOpenApi()
             .WithSummary("A list of authentication scope configurations for your application. This will include the two default scopes of SignIn and StepUp.")
             .Produces<GetAuthenticationConfigurationsResult>()
             .RequireSecretKey();
@@ -41,6 +41,7 @@ public static class AuthenticationConfigurationEndpoints
 
                 return Created();
             })
+            .WithOpenApi()
             .WithSummary("Creates an authentication configuration for the authentication process. In order to use this, it will have to be provided to the `stepup` client method via the purpose field")
             .Produces(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
@@ -56,6 +57,7 @@ public static class AuthenticationConfigurationEndpoints
 
                 return NoContent();
             })
+            .WithOpenApi()
             .WithSummary("Updates an authentication configuration for the authentication process. In order to use this, it will have to be provided to the `stepup` client method via the purpose field")
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound)
@@ -77,6 +79,7 @@ public static class AuthenticationConfigurationEndpoints
 
                 return NoContent();
             })
+            .WithOpenApi()
             .WithSummary("Deletes an authentication configuration for the provided purpose.")
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status400BadRequest)

--- a/src/Api/Endpoints/Signin.cs
+++ b/src/Api/Endpoints/Signin.cs
@@ -22,7 +22,6 @@ public static class SigninEndpoints
     {
         var group = app.MapGroup("/signin")
             .RequireCors("default")
-            .WithOpenApi()
             .WithTags(OpenApiTags.SignIn);
 
         group.MapPost("/generate-token", GenerateTokenAsync)


### PR DESCRIPTION
### Description
ApiKey and ApiSecret fields had 2 to more entries when viewing the API documentation at `/swagger/index.html`.

### Shape

Removed `.WithOpenApi()` from grouped endpoint builders, and moved it to individually to prevent the same bug happening.

### Screenshots

<img width="816" alt="image" src="https://github.com/user-attachments/assets/e85ee12a-4c04-4a2b-a1c3-730994c81079">


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
