### PR TITLE
PAS-544 | Defect when a user cannot immediately delete their application expected copy is not shown

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor
@@ -6,7 +6,7 @@
 <Panel Header="Delete Application">
     @if (Application.DeleteAt.HasValue)
     {
-        <EditForm FormName="@CancelDeleteFormName" Model="@CancelDeleteForm" OnValidSubmit="@OnCancelDeleteValidSubmittedAsync">
+        <EditForm id="@CancelDeleteFormName" FormName="@CancelDeleteFormName" Model="@CancelDeleteForm" OnValidSubmit="@OnCancelDeleteValidSubmittedAsync">
             <Alert Style="@ContextualStyles.Danger">
                 '@Application.Id' will be deleted on '@Application.DeleteAt?.ToString("g") UTC'. If you would like to cancel this action, click 'Cancel'.
             </Alert>
@@ -16,14 +16,14 @@
     }
     else
     {
-        <EditForm FormName="@DeleteFormName" Model="@DeleteForm" OnValidSubmit="@OnDeleteValidSubmittedAsync">
+        <EditForm id="@DeleteFormName" FormName="@DeleteFormName" Model="@DeleteForm" OnValidSubmit="@OnDeleteValidSubmittedAsync">
             @if (CanDeleteImmediately.HasValue && !CanDeleteImmediately.Value)
             {
-                <p>
+                <p id="cannot-delete-immediately-reason">
                     Because your application contains credentials, <strong>you cannot delete it immediately</strong>. Instead, the following will happen once you choose to delete the application:
                 </p>
 
-                <ul role="list" class="list-decimal list-inside my-2">
+                <ul id="cannot-delete-immediately-impact" role="list" class="list-decimal list-inside my-2">
                     <li class="">No data will be deleted immediately.</li>
                     <li>Your API Keys will be frozen - meaning no authentication calls can be made.</li>
                     <li>Admins can cancel the process at any time. The API will return to normal behavior.</li>

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor
@@ -17,7 +17,7 @@
     else
     {
         <EditForm FormName="@DeleteFormName" Model="@DeleteForm" OnValidSubmit="@OnDeleteValidSubmittedAsync">
-            @if (CanDeleteImmediately != null && !CanDeleteImmediately.Value)
+            @if (CanDeleteImmediately.HasValue && !CanDeleteImmediately.Value)
             {
                 <p>
                     Because your application contains credentials, <strong>you cannot delete it immediately</strong>. Instead, the following will happen once you choose to delete the application:

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor.cs
@@ -1,6 +1,7 @@
 using System.Web;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.EntityFrameworkCore;
 using Passwordless.AdminConsole.Helpers;
 using Passwordless.AdminConsole.Models;
 
@@ -41,7 +42,7 @@ public partial class DeleteApplicationSection : ComponentBase
         CancelDeleteFormContext = new EditContext(CancelDeleteForm);
         CancelDeleteFormValidationMessageStore = new ValidationMessageStore(CancelDeleteFormContext);
 
-        if (Application.DeleteAt.HasValue)
+        if (!Application.DeleteAt.HasValue)
         {
             CanDeleteImmediately = await AppService.CanDeleteApplicationImmediatelyAsync(Application.Id);
         }
@@ -79,7 +80,7 @@ public partial class DeleteApplicationSection : ComponentBase
                 NavigationManager.Refresh();
             }
         }
-        catch (Exception ex)
+        catch (DbUpdateException ex)
         {
             Logger.LogError(ex, "Failed to delete application: {appName}.", appId);
             NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode(ex.Message)}");
@@ -99,7 +100,7 @@ public partial class DeleteApplicationSection : ComponentBase
             await AppService.CancelDeletionForApplicationAsync(Application.Id);
             NavigationManager.Refresh();
         }
-        catch (Exception ex)
+        catch (DbUpdateException ex)
         {
             Logger.LogError("Failed to cancel application deletion for application: {appId}", Application.Id);
             NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode(ex.Message)}");

--- a/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor.cs
+++ b/src/AdminConsole/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSection.razor.cs
@@ -9,7 +9,6 @@ namespace Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsCompon
 
 public partial class DeleteApplicationSection : ComponentBase
 {
-    public const string Unknown = "unknown";
     public const string CancelDeleteFormName = "cancel-delete-application-form";
     public const string DeleteFormName = "delete-application-form";
 
@@ -57,15 +56,9 @@ public partial class DeleteApplicationSection : ComponentBase
         }
 
         var appId = Application.Id;
-        var userName = HttpContextAccessor.HttpContext!.User.Identity!.Name ?? Unknown;
 
-        if (userName == Unknown)
-        {
-            Logger.LogError("Failed to delete application with name: {appName} and by user: {username}.", appId, userName);
-            const string message = "Something unexpected happened.";
-            NavigationManager.NavigateTo($"/Error?Message={HttpUtility.UrlEncode(message)}");
-            return;
-        }
+        var userName = HttpContextAccessor.HttpContext!.User.Identity!.Name
+                       ?? throw new InvalidOperationException("User name is not available.");
 
         try
         {

--- a/tests/AdminConsole.Tests/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSectionTests.cs
+++ b/tests/AdminConsole.Tests/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSectionTests.cs
@@ -1,0 +1,106 @@
+using Bunit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents;
+using Passwordless.AdminConsole.Models;
+using Passwordless.AdminConsole.Services;
+using Xunit;
+
+namespace Passwordless.AdminConsole.Tests.Components.Pages.App.Settings.SettingsComponents;
+
+public class DeleteApplicationSectionTests : TestContext
+{
+    private readonly Mock<IApplicationService> _appServiceMock = new();
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock = new();
+    private readonly Mock<ILogger<DeleteApplicationSection>> _loggerMock = new();
+
+    public DeleteApplicationSectionTests()
+    {
+        // Arrange
+        Services.AddSingleton(_appServiceMock.Object);
+        Services.AddSingleton(_httpContextAccessorMock.Object);
+        Services.AddSingleton(_loggerMock.Object);
+    }
+
+    [Fact]
+    public void Renders_CannotDeleteImmediatelyParagraphs_WhenCannotDeleteImmediately()
+    {
+        // Arrange
+        var application = new Application { Id = "app1", Name = "App1" };
+        _appServiceMock.Setup(x =>
+                x.CanDeleteApplicationImmediatelyAsync(It.Is<string>(p => p == application.Id)))
+            .ReturnsAsync(false);
+
+        // Act
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Assert
+        var actual1 = cut.Find("#cannot-delete-immediately-reason");
+        Assert.NotNull(actual1);
+        var actual2 = cut.Find("#cannot-delete-immediately-impact");
+        Assert.NotNull(actual2);
+    }
+
+    [Fact]
+    public void DoesNotRender_CannotDeleteImmediatelyParagraphs_WhenCanDeleteImmediately()
+    {
+        // Arrange
+        var application = new Application { Id = "app1", Name = "App1" };
+        _appServiceMock.Setup(x =>
+                x.CanDeleteApplicationImmediatelyAsync(It.Is<string>(p => p == application.Id)))
+            .ReturnsAsync(true);
+
+        // Act
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Assert
+        Assert.Throws<ElementNotFoundException>(() => cut.Find("#cannot-delete-immediately-reason"));
+        Assert.Throws<ElementNotFoundException>(() => cut.Find("#cannot-delete-immediately-impact"));
+    }
+
+    [Fact]
+    public void Renders_ExpectedForms_WhenIsPendingDeletion()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Id = "app1",
+            Name = "App1",
+            DeleteAt = DateTime.UtcNow.AddMonths(1)
+        };
+
+        // Act
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Assert
+        var actual = cut.Find($"#{DeleteApplicationSection.CancelDeleteFormName}");
+        Assert.NotNull(actual);
+        Assert.Throws<ElementNotFoundException>(() => cut.Find($"#{DeleteApplicationSection.DeleteFormName}"));
+    }
+
+    [Fact]
+    public void DoesNotRender_ExpectedForms_WhenIsNotPendingDeletion()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Id = "app1",
+            Name = "App1",
+            DeleteAt = null
+        };
+
+        // Act
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Assert
+        Assert.Throws<ElementNotFoundException>(() => cut.Find($"#{DeleteApplicationSection.CancelDeleteFormName}"));
+        var actual = cut.Find($"#{DeleteApplicationSection.DeleteFormName}");
+        Assert.NotNull(actual);
+    }
+}

--- a/tests/AdminConsole.Tests/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSectionTests.cs
+++ b/tests/AdminConsole.Tests/Components/Pages/App/Settings/SettingsComponents/DeleteApplicationSectionTests.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using Bunit;
+using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -6,6 +8,7 @@ using Moq;
 using Passwordless.AdminConsole.Components.Pages.App.Settings.SettingsComponents;
 using Passwordless.AdminConsole.Models;
 using Passwordless.AdminConsole.Services;
+using Passwordless.Common.Models.Apps;
 using Xunit;
 
 namespace Passwordless.AdminConsole.Tests.Components.Pages.App.Settings.SettingsComponents;
@@ -102,5 +105,100 @@ public class DeleteApplicationSectionTests : TestContext
         Assert.Throws<ElementNotFoundException>(() => cut.Find($"#{DeleteApplicationSection.CancelDeleteFormName}"));
         var actual = cut.Find($"#{DeleteApplicationSection.DeleteFormName}");
         Assert.NotNull(actual);
+    }
+
+    [Fact]
+    public void SubmittingDeleteForm_WithIncorrectNameConfirmation_ShowsValidationMessage()
+    {
+        // Arrange
+        var application = new Application { Id = "app1", Name = "App1" };
+        _appServiceMock.Setup(x =>
+                x.CanDeleteApplicationImmediatelyAsync(It.Is<string>(p => p == application.Id)))
+            .ReturnsAsync(true);
+
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Act
+        cut.Find("form").Submit();
+
+        // Assert
+        var actualErrors = cut.Find("ul.validation-errors");
+        Assert.Contains(actualErrors.Children, x => x.TextContent == "Name confirmation does not match.");
+    }
+
+    [Fact]
+    public void SubmittingDeleteForm_WithCorrectNameConfirmation_NavigatesAwayWhenSuccessful()
+    {
+        // Arrange
+        var application = new Application { Id = "app1", Name = "App1" };
+        _appServiceMock.Setup(x =>
+                x.CanDeleteApplicationImmediatelyAsync(It.Is<string>(p => p == application.Id)))
+            .ReturnsAsync(true);
+
+        const string username = "John Doe";
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(new Claim(ClaimTypes.Name, username));
+        var principal = new ClaimsPrincipal(identity);
+        _httpContextAccessorMock.SetupGet(x => x.HttpContext.User).Returns(principal);
+
+        var expectedDeleteResponse = new MarkDeleteApplicationResponse(true, new DateTime(2024, 1, 1), ["johndoe@example.org"]);
+
+        _appServiceMock.Setup(x =>
+                x.MarkDeleteApplicationAsync(
+                    It.Is<string>(p => p == application.Id),
+                    It.Is<string>(p => p == username)))
+            .ReturnsAsync(expectedDeleteResponse);
+
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Act
+        cut.Find("input[name='DeleteForm.NameConfirmation']").Change("App1");
+        cut.Find($"form#{DeleteApplicationSection.DeleteFormName}").Submit();
+
+        // Assert
+        Assert.Throws<ElementNotFoundException>(() => cut.Find("ul.validation-errors"));
+
+        _appServiceMock.Verify(x =>
+            x.MarkDeleteApplicationAsync(
+                It.Is<string>(p => p == application.Id),
+                It.Is<string>(p => p == username)), Times.Once);
+
+        var navMan = Services.GetRequiredService<FakeNavigationManager>();
+        Assert.Equal("http://localhost/Organization/Overview", navMan.Uri);
+    }
+
+    [Fact]
+    public void SubmittingCancelDeleteForm_WithCorrectNameConfirmation_NavigatesToSamePageWhenSuccessful()
+    {
+        // Arrange
+        var application = new Application
+        {
+            Id = "app1",
+            Name = "App1",
+            DeleteAt = DateTime.UtcNow.AddMonths(1)
+        };
+
+        const string username = "John Doe";
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(new Claim(ClaimTypes.Name, username));
+        var principal = new ClaimsPrincipal(identity);
+        _httpContextAccessorMock.SetupGet(x => x.HttpContext.User).Returns(principal);
+
+        var cut = RenderComponent<DeleteApplicationSection>(c =>
+            c.Add(p => p.Application, application));
+
+        // Act
+        cut.Find($"form#{DeleteApplicationSection.CancelDeleteFormName}").Submit();
+
+        // Assert
+        Assert.Throws<ElementNotFoundException>(() => cut.Find("ul.validation-errors"));
+
+        _appServiceMock.Verify(x =>
+            x.CancelDeletionForApplicationAsync(It.Is<string>(p => p == application.Id)), Times.Once);
+
+        var navMan = Services.GetRequiredService<FakeNavigationManager>();
+        Assert.Equal("http://localhost/", navMan.Uri);
     }
 }


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-544](https://bitwarden.atlassian.net/browse/PAS-544)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

- Shows expected copy/text depending on application state.
- Does not throw exception anymore when submitting the forms.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-544]: https://bitwarden.atlassian.net/browse/PAS-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ