### PR TITLE
PAS-552 | CurrentUserCount no longer updating

### DIFF
--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -85,15 +85,14 @@ async Task RunAppAsync()
     builder.Services.AddTransient<IPostSignInHandlerService, PostSignInHandlerService>();
     services.ConfigureApplicationCookie(o =>
     {
-        o.Events.OnSignedIn = context =>
+        o.Events.OnSignedIn = async context =>
         {
             var organizationId = context.Principal!.GetOrgId();
             if (organizationId.HasValue)
             {
                 var postSignInHandler = context.HttpContext.RequestServices.GetRequiredService<IPostSignInHandlerService>();
-                return postSignInHandler.HandleAsync(organizationId.Value);
+                await postSignInHandler.HandleAsync(organizationId.Value);
             }
-            return Task.CompletedTask;
         };
         o.Cookie.Name = "AdminConsoleSignIn";
         o.ExpireTimeSpan = TimeSpan.FromHours(2);

--- a/src/AdminConsole/Services/IPostSignInHandlerService.cs
+++ b/src/AdminConsole/Services/IPostSignInHandlerService.cs
@@ -1,8 +1,6 @@
-using System.Security.Claims;
-
 namespace Passwordless.AdminConsole.Services;
 
 public interface IPostSignInHandlerService
 {
-    Task HandleAsync();
+    Task HandleAsync(int organizationId);
 }

--- a/src/AdminConsole/Services/PostSignInHandlerService.cs
+++ b/src/AdminConsole/Services/PostSignInHandlerService.cs
@@ -1,6 +1,4 @@
-using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
-using Passwordless.AdminConsole.Authorization;
 using Passwordless.AdminConsole.Db;
 using Passwordless.AdminConsole.Middleware;
 
@@ -9,28 +7,21 @@ namespace Passwordless.AdminConsole.Services;
 public class PostSignInHandlerService : IPostSignInHandlerService
 {
     private readonly ConsoleDbContext _db;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<PostSignInHandlerService> _logger;
+    private readonly IServiceProvider _serviceProvider;
 
     public PostSignInHandlerService(
         ConsoleDbContext db,
-        IHttpContextAccessor httpContextAccessor,
         IServiceProvider serviceProvider,
         ILogger<PostSignInHandlerService> logger)
     {
         _db = db;
-        _httpContextAccessor = httpContextAccessor;
-        _serviceProvider = serviceProvider;
         _logger = logger;
+        _serviceProvider = serviceProvider;
     }
 
-    public async Task HandleAsync()
+    public async Task HandleAsync(int organizationId)
     {
-        var user = _httpContextAccessor.HttpContext.User;
-        var organizationIdValue = user.FindFirstValue(CustomClaimTypes.OrgId);
-        if (organizationIdValue == null) return;
-        var organizationId = int.Parse(organizationIdValue);
         var applications = await _db.Applications
             .Where(x => x.OrganizationId == organizationId && !x.DeleteAt.HasValue)
             .ToListAsync();


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-552](https://bitwarden.atlassian.net/browse/PAS-552)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

The `CurrentUserCount` was no longer being updated in the `Applications` table of the admin console. This was happening because we listen to the `OnSignedIn` callback, where we are successfully able to listen when an admin signs in and execute custom code to perform certain actions, such as updating and caching the amount of users.

The caching of the amount of users was running on a background job half a year ago which was running every few hours, but was causing an unnecessary amount of network traffic.

We injected an object which is responsible for handling any post signin events, but it turns out the `ClaimsPrincipal` is not signed in inside this handler, although the `ClaimsPrincipal is signed in inside the `ConfigureApplicationCookie` method in `Program.css`.

We pass the `OrganizationId` for now as a parameter to the handler.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-552]: https://bitwarden.atlassian.net/browse/PAS-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ