### PR TITLE
PAS-552 | Restore BackgroundService for Bitwarden's internal reporting

### DIFF
--- a/src/AdminConsole/Billing/BackgroundServices/UserCountUpdaterBackgroundService.cs
+++ b/src/AdminConsole/Billing/BackgroundServices/UserCountUpdaterBackgroundService.cs
@@ -1,0 +1,33 @@
+using Passwordless.AdminConsole.Services;
+using Passwordless.Common.Background;
+
+namespace Passwordless.AdminConsole.Billing.BackgroundServices;
+
+/// <summary>
+/// Responsible for retrieving the current user count from the Passwordless API and storing it in the Admin Console.
+/// It is only required for Bitwarden's internal reporting.
+/// </summary>
+public sealed class UserCountUpdaterBackgroundService(
+    IServiceProvider serviceProvider,
+    TimeProvider timeProvider,
+    ILogger<UserCountUpdaterBackgroundService> logger)
+    : BaseDelayedPeriodicBackgroundService(
+        new TimeOnly(0, 0),
+        TimeSpan.FromDays(1),
+        timeProvider,
+        logger)
+{
+    protected override async Task DoWorkAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope scope = serviceProvider.CreateScope();
+            var usageService = scope.ServiceProvider.GetRequiredService<IUsageService>();
+            await usageService.UpdateUsersCountAsync();
+        }
+        catch (Exception e)
+        {
+            logger.LogCritical(e, $"{nameof(UserCountUpdaterBackgroundService)} failed.");
+        }
+    }
+}

--- a/src/AdminConsole/Billing/BillingBootstrap.cs
+++ b/src/AdminConsole/Billing/BillingBootstrap.cs
@@ -25,6 +25,7 @@ public static class BillingBootstrap
             builder.Services.AddHostedService<StripeConfigurationUpdaterBackgroundService>();
             builder.Services.AddScoped<ISharedBillingService, SharedStripeBillingService>();
             builder.Services.AddHostedService<MeteredBillingBackgroundService>();
+            builder.Services.AddHostedService<UserCountUpdaterBackgroundService>();
         }
     }
 }


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-552](https://bitwarden.atlassian.net/browse/PAS-552)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

Restore `UserCountUpdaterBackgroundService` for use in internal reporting at Bitwarden which happens bi-weekly. This service was initially dropped due to performance reasons.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-552]: https://bitwarden.atlassian.net/browse/PAS-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ