### PR TITLE
PAS-556 | Add support for credential hints to the register flow

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
-    <PackageReference Include="Passwordless.AspNetCore" Version="2.0.0-beta10" />
+    <PackageReference Include="Passwordless.AspNetCore" Version="2.1.0-beta.1" />
     <PackageReference Include="Stripe.net" Version="41.*" />
   </ItemGroup>
 

--- a/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml
+++ b/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml
@@ -12,7 +12,6 @@
     var requestToken = Antiforgery.GetAndStoreTokens(Model.HttpContext).RequestToken;
 }
 
-
 <div>
     <div class="flex flex-1 flex-col justify-center lg:flex-non bg-gray-200 rounded-md p-6 max-w-fit">
         <div class="w-full max-w-sm lg:w-96">
@@ -85,6 +84,13 @@
                                 }
                             </div>
 
+                            <div>
+                                <label for="hints" class="block text-sm font-medium leading-6 text-gray-900">Credential hints (optional)</label>
+                                <div class="mt-2">
+                                    <input asp-for="Hints" type="text" name="hints" id="hints" class="text-input">
+                                    <span asp-validation-for="Hints"></span>
+                                </div>
+                            </div>
 
                             <div>
                                 <button id="register-btn" class="btn-primary" type="button">Register</button>
@@ -127,7 +133,7 @@ const createNewAccount = async (e) => {
     if (req.ok) {
         const { token } = await req.json();
         const nicknameForDevice = data.get("nickname");
-        const { error } = await p.register(token , nicknameForDevice);
+        const { error } = await p.register(token, nicknameForDevice);
 
         if (error) {
             console.error(error);

--- a/src/Service/Fido2Service.cs
+++ b/src/Service/Fido2Service.cs
@@ -74,7 +74,7 @@ public class Fido2Service : IFido2Service
         if (string.IsNullOrEmpty(tokenProps.Attestation)) tokenProps.Attestation = "none";
         TokenValidator.ValidateAttestation(tokenProps, features);
 
-        // check if aliases is available
+        // Check if aliases is available
         if (tokenProps.Aliases != null)
         {
             var hashedAliases = tokenProps.Aliases.Select(alias => HashAlias(alias, _tenantProvider.Tenant));
@@ -151,6 +151,8 @@ public class Fido2Service : IFido2Service
                 {
                     CredProps = true
                 });
+
+            options.Hints = token.Hints;
 
             var session = await _tokenService.EncodeTokenAsync(
                 new RegisterSession

--- a/src/Service/Models/RegisterToken.cs
+++ b/src/Service/Models/RegisterToken.cs
@@ -33,7 +33,7 @@ public class RegisterToken : Token
 
     [MessagePack.Key(17)]
     [MaxLength(10), MaxLengthCollection(250), RequiredCollection(AllowEmptyStrings = false)]
-    public HashSet<string>? Aliases { get; set; } = null;
+    public HashSet<string>? Aliases { get; set; }
 
     [MessagePack.Key(18)]
     public bool AliasHashing { get; set; } = true;

--- a/src/Service/Models/RegisterToken.cs
+++ b/src/Service/Models/RegisterToken.cs
@@ -33,7 +33,7 @@ public class RegisterToken : Token
 
     [MessagePack.Key(17)]
     [MaxLength(10), MaxLengthCollection(250), RequiredCollection(AllowEmptyStrings = false)]
-    public HashSet<string> Aliases { get; set; } = [];
+    public HashSet<string>? Aliases { get; set; } = null;
 
     [MessagePack.Key(18)]
     public bool AliasHashing { get; set; } = true;

--- a/src/Service/Models/RegisterToken.cs
+++ b/src/Service/Models/RegisterToken.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Fido2NetLib.Objects;
 using MessagePack;
 using Passwordless.Common.Validation;
 
@@ -20,17 +21,26 @@ public class RegisterToken : Token
 
     [MessagePack.Key(13)]
     public string Attestation { get; set; } = "None";
+
     [MessagePack.Key(14)]
     public string AuthenticatorType { get; set; }
+
     [MessagePack.Key(15)]
     public bool Discoverable { get; set; } = true;
+
     [MessagePack.Key(16)]
     public string UserVerification { get; set; } = "Preferred";
+
     [MessagePack.Key(17)]
     [MaxLength(10), MaxLengthCollection(250), RequiredCollection(AllowEmptyStrings = false)]
-    public HashSet<string> Aliases { get; set; }
+    public HashSet<string> Aliases { get; set; } = [];
 
-    [MessagePack.Key(18)] public bool AliasHashing { get; set; } = true;
+    [MessagePack.Key(18)]
+    public bool AliasHashing { get; set; } = true;
+
+    [MessagePack.Key(19)]
+    [MaxLength(3)]
+    public IReadOnlyList<PublicKeyCredentialHint> Hints { get; set; } = [];
 }
 
 [MessagePackObject]

--- a/src/Service/TokenService.cs
+++ b/src/Service/TokenService.cs
@@ -149,31 +149,25 @@ public class TokenService : ITokenService
 
     public async Task<string> EncodeTokenAsync<T>(T token, string prefix, bool contractless = false)
     {
-        byte[] msgpack;
-        if (contractless)
-        {
-            msgpack = MessagePackSerializer.Serialize(token, ContractlessStandardResolver.Options);
-        }
-        else
-        {
-            msgpack = MessagePackSerializer.Serialize(token);
-        }
+        var msgpack = contractless
+            ? MessagePackSerializer.Serialize(token, ContractlessStandardResolver.Options)
+            : MessagePackSerializer.Serialize(token);
 
-        (Key key, int keyId) = await GetRandomKeyAsync();
+        (Key key, var keyId) = await GetRandomKeyAsync();
 
         _log.LogInformation("Encoding using keyId={keyId}", keyId);
         var mac = CreateMac(key, msgpack);
 
         var envelope = new MacEnvelope { Mac = mac, Token = msgpack, KeyId = keyId };
-        var envelop_binary = MessagePackSerializer.Serialize(envelope);
-        var envelop_binary_b64 = Base64Url.Encode(envelop_binary);
+        var envelopeBinary = MessagePackSerializer.Serialize(envelope);
+        var envelopeBinaryB64 = Base64Url.Encode(envelopeBinary);
 
         if (!string.IsNullOrEmpty(prefix))
         {
-            return prefix + envelop_binary_b64;
+            return prefix + envelopeBinaryB64;
         }
 
-        return envelop_binary_b64;
+        return envelopeBinaryB64;
     }
 
     /// <summary>

--- a/tests/Service.Tests/Implementations/Fido2ServiceTests.cs
+++ b/tests/Service.Tests/Implementations/Fido2ServiceTests.cs
@@ -74,7 +74,7 @@ public class Fido2ServiceTests
             .ReturnsAsync("test_token");
         _mockFeatureContextProvider.Setup(x => x.UseContext()).ReturnsAsync(new FeaturesContext(false, 0, null, 10000, false, true, true));
         _mockTenantStorage.Setup(x => x.GetUsersCount()).ReturnsAsync(10000);
-        _mockTenantStorage.Setup(x => x.GetCredentialsByUserIdAsync(It.Is<string>(p => p == "test"))).ReturnsAsync(new List<StoredCredential>(0));
+        _mockTenantStorage.Setup(x => x.GetCredentialsByUserIdAsync(It.Is<string>(p => p == "test"))).ReturnsAsync([]);
 
         // act
         var actual = await Assert.ThrowsAsync<ApiException>(async () =>
@@ -104,7 +104,19 @@ public class Fido2ServiceTests
         _mockFeatureContextProvider.Setup(x => x.UseContext()).ReturnsAsync(new FeaturesContext(false, 0, null, 10000, false, true, true));
         _mockTenantStorage.Setup(x => x.GetUsersCount()).ReturnsAsync(10000);
         _mockTenantStorage.Setup(x => x.GetCredentialsByUserIdAsync(It.Is<string>(p => p == "test"))).ReturnsAsync(
-            new List<StoredCredential>(1) { new() { UserHandle = "test"u8.ToArray(), Descriptor = null!, Origin = null!, AttestationFmt = null!, CreatedAt = DateTime.UtcNow, PublicKey = null!, SignatureCounter = 123, RPID = null! } });
+        [
+            new StoredCredential
+            {
+                UserHandle = "test"u8.ToArray(),
+                Descriptor = null!,
+                Origin = null!,
+                AttestationFmt = null!,
+                CreatedAt = DateTime.UtcNow,
+                PublicKey = null!,
+                SignatureCounter = 123,
+                RPID = null!
+            }
+        ]);
 
         // act
         var actual = await _sut.CreateRegisterTokenAsync(new RegisterToken


### PR DESCRIPTION
<!--
Thank you for contributing! Please follow the steps below to help us process your PR quickly.
- 📝 Use a meaningful title for the pull request, e.g: "PAS-XXX | short pr description"
- 💭 Write a clear description and share screenshots (if applicable) to help describe your change.
- 🔍 Not all sections below will apply to you and are mostly for our internal team. It's okay to delete them if they are not applicable. 
-->

### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes https://bitwarden.atlassian.net/browse/PAS-556

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description
<!--
    Introduction that should allow the reviewer to quickly be able to understand the reason for opening this PR.
-->

This adds an ability to provide credential hints to the `/register` endpoint.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- I used the Playground to verify that setting different hints results in different behavior

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
