### PR TITLE
PAS-554 | Fix Access Denied creating application in different session

### DIFF
--- a/src/AdminConsole/Authorization/CustomClaimTypes.cs
+++ b/src/AdminConsole/Authorization/CustomClaimTypes.cs
@@ -3,5 +3,4 @@ namespace Passwordless.AdminConsole.Authorization;
 public static class CustomClaimTypes
 {
     public const string OrgId = "OrgId";
-    public const string AppId = "AppId";
 }

--- a/src/AdminConsole/Services/CustomUserClaimsPrincipalFactory.cs
+++ b/src/AdminConsole/Services/CustomUserClaimsPrincipalFactory.cs
@@ -1,40 +1,25 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using Passwordless.AdminConsole.Db;
+using Passwordless.AdminConsole.Authorization;
 using Passwordless.AdminConsole.Identity;
 
 namespace Passwordless.AdminConsole.Services;
 
 public class CustomUserClaimsPrincipalFactory : UserClaimsPrincipalFactory<ConsoleAdmin>
 {
-    private readonly ConsoleDbContext _db;
-
     public CustomUserClaimsPrincipalFactory(
         UserManager<ConsoleAdmin> userManager,
-        IOptions<IdentityOptions> optionsAccessor,
-        ConsoleDbContext db
+        IOptions<IdentityOptions> optionsAccessor
     )
         : base(userManager, optionsAccessor)
     {
-        _db = db;
     }
 
     protected override async Task<ClaimsIdentity> GenerateClaimsAsync(ConsoleAdmin user)
     {
         ClaimsIdentity identity = await base.GenerateClaimsAsync(user);
-        identity.AddClaim(new Claim("OrgId", user.OrganizationId.ToString()));
-
-        // add apps
-        List<string> apps = await _db.Applications.Where(a => a.OrganizationId == user.OrganizationId)
-            .Select(a => a.Id).ToListAsync();
-
-        foreach (var appId in apps)
-        {
-            identity.AddClaim(new Claim("AppId", appId));
-        }
-
+        identity.AddClaim(new Claim(CustomClaimTypes.OrgId, user.OrganizationId.ToString()));
         return identity;
     }
 }


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-554](https://bitwarden.atlassian.net/browse/PAS-554)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

When an admin signs in, all the applications belonging to the organization are added to the claims/token. When an application is added in a different session, you will get an access denied message in your old session, because it doesn't know the application was created for your organization.

Under very particular circumstances, where all the stars would have to align (never happens), you could theoretically access an application of a different organization. Although the impact would be fairly small as that application would have to be newly created by the new organization, and deleted by the old one in quick succession.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-554]: https://bitwarden.atlassian.net/browse/PAS-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ