### PR TITLE
PAS-559 | Authorization handler is being executed concurrently.

### DIFF
--- a/src/AdminConsole/Authorization/HasAppHandler.cs
+++ b/src/AdminConsole/Authorization/HasAppHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 using Passwordless.AdminConsole.Db;
 using Passwordless.AdminConsole.Helpers;
 using Passwordless.AdminConsole.Middleware;
@@ -14,17 +15,15 @@ public class HasAppHandler : AuthorizationHandler<HasAppRoleRequirement>
         _dbContext = dbContext;
     }
 
-    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, HasAppRoleRequirement requirement)
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, HasAppRoleRequirement requirement)
     {
-        if (HasAppInTenant(context))
+        if (await HasAppInTenant(context))
         {
             context.Succeed(requirement);
         }
-
-        return Task.CompletedTask;
     }
 
-    private bool HasAppInTenant(AuthorizationHandlerContext context)
+    private async Task<bool> HasAppInTenant(AuthorizationHandlerContext context)
     {
         if (context.Resource is not HttpContext httpContext)
         {
@@ -46,6 +45,6 @@ public class HasAppHandler : AuthorizationHandler<HasAppRoleRequirement>
 
         var appId = appIdObj!.ToString();
 
-        return _dbContext.Applications.Any(x => x.OrganizationId == organizationId.Value && x.Id == appId);
+        return await _dbContext.Applications.AnyAsync(x => x.OrganizationId == organizationId.Value && x.Id == appId);
     }
 }

--- a/src/AdminConsole/Authorization/HasAppHandler.cs
+++ b/src/AdminConsole/Authorization/HasAppHandler.cs
@@ -9,18 +9,25 @@ namespace Passwordless.AdminConsole.Authorization;
 public class HasAppHandler : AuthorizationHandler<HasAppRoleRequirement>
 {
     private readonly ConsoleDbContext _dbContext;
+    private readonly ILogger<HasAppHandler> _logger;
 
-    public HasAppHandler(ConsoleDbContext dbContext)
+    public HasAppHandler(
+        ConsoleDbContext dbContext,
+        ILogger<HasAppHandler> logger)
     {
         _dbContext = dbContext;
+        _logger = logger;
     }
 
     protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, HasAppRoleRequirement requirement)
     {
+        _logger.LogInformation("Checking if user has app in tenant - START");
         if (await HasAppInTenant(context))
         {
             context.Succeed(requirement);
         }
+        _logger.LogInformation("Checking if user has app in tenant - END");
+
     }
 
     private async Task<bool> HasAppInTenant(AuthorizationHandlerContext context)

--- a/src/AdminConsole/Components/Layouts/ApplicationNavMenu.razor
+++ b/src/AdminConsole/Components/Layouts/ApplicationNavMenu.razor
@@ -1,29 +1,24 @@
 @inject ICurrentContext CurrentContext
-@inject IHttpContextAccessor HttpContextAccessor
 
-<AuthorizeView Resource="@HttpContextAccessor.HttpContext" Policy="@CustomPolicy.HasAppRole">
-    <Authorized>
-        <div id="app-submenu" class="nav-link-submenu">
-            <div class="nav-link-submenu-title">App: @CurrentContext.AppId</div>
-            @if (!CurrentContext.IsPendingDelete)
+@if (CurrentContext.InAppContext)
+{
+    <div id="app-submenu" class="nav-link-submenu">
+        <div class="nav-link-submenu-title">App: @CurrentContext.AppId</div>
+        @if (!CurrentContext.IsPendingDelete)
+        {
+            <NavMenuItem Href="@OnboardingUrl" Icon="typeof(StartIcon)" Label="Getting Started" />
+            <NavMenuItem Href="@PlaygroundUrl" Icon="typeof(BeakerIcon)" Label="Playground" />
+            <NavMenuItem Href="@UsersUrl" Icon="typeof(UsersIcon)" Label="Users" />
+            <NavMenuItem Href="@ReportingUrl" Icon="typeof(StackedBarChartIcon)" Label="Reporting" />
+
+            @if (CurrentContext.Features.EventLoggingIsEnabled)
             {
-                <NavMenuItem Href="@OnboardingUrl" Icon="typeof(StartIcon)" Label="Getting Started" />
-                <NavMenuItem Href="@PlaygroundUrl" Icon="typeof(BeakerIcon)" Label="Playground" />
-                <NavMenuItem Href="@UsersUrl" Icon="typeof(UsersIcon)" Label="Users" />
-                <NavMenuItem Href="@ReportingUrl" Icon="typeof(StackedBarChartIcon)" Label="Reporting" />
-
-                @if (CurrentContext.Features.EventLoggingIsEnabled)
-                {
-                    <NavMenuItem Href="@AppLogsUrl" Icon="typeof(CodeBracketSquareIcon)" Label="App Logs" />
-                }
+                <NavMenuItem Href="@AppLogsUrl" Icon="typeof(CodeBracketSquareIcon)" Label="App Logs" />
             }
-            <NavMenuItem Href="@SettingsUrl" Icon="typeof(CogIcon)" Label="Settings" />
-        </div>
-    </Authorized>
-    <NotAuthorized>
-        <!-- Empty -->
-    </NotAuthorized>
-</AuthorizeView>
+        }
+        <NavMenuItem Href="@SettingsUrl" Icon="typeof(CogIcon)" Label="Settings" />
+    </div>
+}
 
 @code {
     private string OnboardingUrl => CurrentContext.InAppContext ? $"/app/{CurrentContext.AppId}/onboarding/get-started" : NavMenu.OrganizationOverviewUrl;

--- a/src/AdminConsole/Components/Layouts/ApplicationNavMenu.razor
+++ b/src/AdminConsole/Components/Layouts/ApplicationNavMenu.razor
@@ -12,7 +12,7 @@
                 <NavMenuItem Href="@UsersUrl" Icon="typeof(UsersIcon)" Label="Users" />
                 <NavMenuItem Href="@ReportingUrl" Icon="typeof(StackedBarChartIcon)" Label="Reporting" />
 
-                if (CurrentContext.Features.EventLoggingIsEnabled)
+                @if (CurrentContext.Features.EventLoggingIsEnabled)
                 {
                     <NavMenuItem Href="@AppLogsUrl" Icon="typeof(CodeBracketSquareIcon)" Label="App Logs" />
                 }

--- a/src/AdminConsole/Components/Pages/Organization/Create.razor
+++ b/src/AdminConsole/Components/Pages/Organization/Create.razor
@@ -1,4 +1,6 @@
-@page "/Organization/Create"
+@page "/organization/create"
+@page "/signup"
+
 @using Microsoft.AspNetCore.Identity
 @using Passwordless.AdminConsole.EventLog.Loggers
 @using Passwordless.AdminConsole.Identity

--- a/src/AdminConsole/Middleware/CurrentContextMiddleware.cs
+++ b/src/AdminConsole/Middleware/CurrentContextMiddleware.cs
@@ -9,10 +9,14 @@ namespace Passwordless.AdminConsole.Middleware;
 public class CurrentContextMiddleware
 {
     private readonly RequestDelegate _next;
+    private readonly ILogger<CurrentContextMiddleware> _logger;
 
-    public CurrentContextMiddleware(RequestDelegate next)
+    public CurrentContextMiddleware(
+        RequestDelegate next,
+        ILogger<CurrentContextMiddleware> logger)
     {
         _next = next;
+        _logger = logger;
     }
 
     // Keep method non-async for non-app calls so that we can avoid the creation of a state machine when it's not needed
@@ -23,6 +27,7 @@ public class CurrentContextMiddleware
         IPasswordlessManagementClient passwordlessClient,
         IOrganizationFeatureService organizationFeatureService)
     {
+        _logger.LogInformation("CurrentContextMiddleware - START");
         var name = httpContext.GetRouteData();
 
         var hasAppRouteValue = name.Values.TryGetValue(RouteParameters.AppId, out var appRouteValue);
@@ -82,5 +87,7 @@ public class CurrentContextMiddleware
 #pragma warning restore CS0618
 
         await _next(httpContext);
+
+        _logger.LogInformation("CurrentContextMiddleware - END");
     }
 }

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -72,8 +72,7 @@ async Task RunAppAsync()
     {
         options.AddTenantRouting();
         options.Conventions.AuthorizeFolder("/");
-        options.Conventions.AuthorizeFolder("/App", CustomPolicy.HasAppRole);
-        options.Conventions.AddPageRoute("/Organization/Create", "/signup");
+        //options.Conventions.AuthorizeFolder("/App", CustomPolicy.HasAppRole);
     });
 
     services.AddScoped<ICurrentContext, CurrentContext>();
@@ -101,7 +100,7 @@ async Task RunAppAsync()
         o.ExpireTimeSpan = TimeSpan.FromHours(2);
     });
 
-    services.AddTransient<IAuthorizationHandler, HasAppHandler>();
+    services.AddScoped<IAuthorizationHandler, HasAppHandler>();
     services.AddAuthorization(c =>
     {
         c.AddPolicy(CustomPolicy.HasAppRole, b =>

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -72,7 +72,7 @@ async Task RunAppAsync()
     {
         options.AddTenantRouting();
         options.Conventions.AuthorizeFolder("/");
-        //options.Conventions.AuthorizeFolder("/App", CustomPolicy.HasAppRole);
+        options.Conventions.AuthorizeFolder("/App", CustomPolicy.HasAppRole);
     });
 
     services.AddScoped<ICurrentContext, CurrentContext>();

--- a/src/AdminConsole/Services/DataService.cs
+++ b/src/AdminConsole/Services/DataService.cs
@@ -27,7 +27,9 @@ public class DataService : IDataService
 
     public async Task<Organization?> GetOrganizationAsync()
     {
-        return await _db.Organizations.FirstOrDefaultAsync(o => o.Id == _orgId);
+        return await _db.Organizations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == _orgId);
     }
 
     public async Task<Organization?> GetOrganizationAsync(int id)
@@ -94,7 +96,9 @@ public class DataService : IDataService
 
     public async Task<Application?> GetApplicationAsync(string applicationId)
     {
-        var application = await _db.Applications.SingleOrDefaultAsync(x => x.Id == applicationId);
+        var application = await _db.Applications
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == applicationId);
         return application;
     }
 

--- a/src/AdminConsole/Services/OrganizationFeatureService.cs
+++ b/src/AdminConsole/Services/OrganizationFeatureService.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Passwordless.AdminConsole.Billing.Configuration;
 using Passwordless.AdminConsole.Db;
@@ -19,6 +20,7 @@ public class OrganizationFeatureService : IOrganizationFeatureService
     public OrganizationFeaturesContext GetOrganizationFeatures(int orgId)
     {
         var billingPlans = _db.Applications
+            .AsNoTracking()
             .Where(x => x.OrganizationId == orgId)
             .GroupBy(x => x.BillingPlan)
             .Select(x => x.Key)

--- a/tests/AdminConsole.Tests/Components/Pages/App/BaseApplicationPageTests.cs
+++ b/tests/AdminConsole.Tests/Components/Pages/App/BaseApplicationPageTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.AspNetCore.Components;
 using Passwordless.AdminConsole.Authorization;
 using Passwordless.AdminConsole.Components.Pages.App;
 using Xunit;
@@ -20,14 +21,15 @@ public class BaseApplicationTests
 
         var componentTypes = assembly.GetTypes()
             .Where(type =>
-                typeof(Microsoft.AspNetCore.Components.ComponentBase).IsAssignableFrom(type) &&
+                typeof(ComponentBase).IsAssignableFrom(type) &&
                 type.Namespace!.StartsWith("Passwordless.AdminConsole.Components.Pages.App"));
 
         foreach (var componentType in componentTypes)
         {
             // Check if the component has a @page directive
-            var pageAttribute = componentType.GetCustomAttribute<Microsoft.AspNetCore.Components.RouteAttribute>();
-            if (pageAttribute != null)
+            var pageAttributes = componentType.GetCustomAttributes<RouteAttribute>();
+
+            if (pageAttributes.Any())
             {
                 // Assert that the component inherits from BaseApplicationPage
                 Assert.True(typeof(BaseApplicationPage).IsAssignableFrom(componentType),

--- a/tests/AdminConsole.Tests/Components/Pages/App/BaseApplicationPageTests.cs
+++ b/tests/AdminConsole.Tests/Components/Pages/App/BaseApplicationPageTests.cs
@@ -53,12 +53,16 @@ public class BaseApplicationTests
         foreach (var componentType in componentTypes)
         {
             // Check if the component has a @page directive
-            var pageAttribute = componentType.GetCustomAttribute<Microsoft.AspNetCore.Components.RouteAttribute>();
-            if (pageAttribute != null && pageAttribute.Template.StartsWith("/app/{app}", StringComparison.InvariantCultureIgnoreCase))
+            var pageAttributes = componentType.GetCustomAttributes<RouteAttribute>();
+
+            foreach (var pageAttribute in pageAttributes)
             {
-                // Assert that the component inherits from BaseApplicationPage
-                Assert.True(typeof(BaseApplicationPage).IsAssignableFrom(componentType),
-                    $"{componentType.Name} should inherit from BaseApplicationPage");
+                if (pageAttribute.Template.StartsWith("/app/{app}", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // Assert that the component inherits from BaseApplicationPage
+                    Assert.True(typeof(BaseApplicationPage).IsAssignableFrom(componentType),
+                        $"{componentType.Name} should inherit from BaseApplicationPage");
+                }
             }
         }
     }

--- a/tests/AdminConsole.Tests/Components/Shared/Layouts/ApplicationNavMenuTests.cs
+++ b/tests/AdminConsole.Tests/Components/Shared/Layouts/ApplicationNavMenuTests.cs
@@ -113,27 +113,10 @@ public class ApplicationNavMenuTests : TestContext
     }
 
     [Fact]
-    public void ApplicationNavMenu_Renders_Nothing_When_HasAppRolePolicyFails()
+    public void ApplicationNavMenu_Renders_Nothing_When_NotInAppContext()
     {
         // Arrange
-        var organizationFeatures = _fixture
-            .Build<OrganizationFeaturesContext>()
-            .With(x => x.EventLoggingIsEnabled, true)
-            .Create();
-        _currentContext.SetupGet(x => x.OrganizationFeatures).Returns(organizationFeatures);
-        var features = _fixture
-            .Build<ApplicationFeatureContext>()
-            .With(x => x.EventLoggingIsEnabled, true)
-            .Create();
-        _currentContext.SetupGet(x => x.Features).Returns(features);
-
-        var organization = _fixture.Build<Organization>()
-            .Without(x => x.Applications)
-            .Without(x => x.Admins)
-            .Create();
-        _currentContext.SetupGet(x => x.Organization).Returns(organization);
-        _currentContext.SetupGet(x => x.IsPendingDelete).Returns(true);
-        _currentContext.SetupGet(x => x.InAppContext).Returns(true);
+        _currentContext.SetupGet(x => x.InAppContext).Returns(false);
         _authorizationContext.SetNotAuthorized();
 
         // Act


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-559](https://bitwarden.atlassian.net/browse/PAS-559)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

1. We will need IDbContextFactory, this won't fix it permanently. Authorization handlers can be executed concurrently when Blazor/Razor components are being rendered.
2. Adds the alias route '/signup' back for '/organization/create'

### Shape

n/a

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-559]: https://bitwarden.atlassian.net/browse/PAS-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ