### PR TITLE
PAS-557 | Show error message when adding duplicate auth config

### DIFF
--- a/src/AdminConsole/Components/Pages/App/Settings/AuthenticationConfiguration/AuthenticationConfigurationForm.razor
+++ b/src/AdminConsole/Components/Pages/App/Settings/AuthenticationConfiguration/AuthenticationConfigurationForm.razor
@@ -6,6 +6,7 @@
 <EditForm Model="FormModel" OnValidSubmit="SubmitAsync" FormName="@FormName" class="space-y-6">
     <DataAnnotationsValidator/>
     <ValidationSummary/>
+    <CustomValidationErrors EditContext="FormEditContext" />
     <div class="sm:w-full sm:max-w-md">
         <label class="block text-sm font-medium leading-6 text-gray-900 my-2" for="Purpose">Purpose:</label>
         <InputText id="Purpose" @bind-Value="@FormModel!.Purpose" readonly="@IsPurposeReadOnly" class="text-input"/>
@@ -41,20 +42,34 @@
 
     [SupplyParameterFromForm]
     public AuthenticationConfigurationFormModel? FormModel { get; set; }
+    
+    public EditContext? FormEditContext { get; set; }
+
+    public ValidationMessageStore? FormValidationMessageStore { get; set; }
 
     private const string FormName = "AuthenticationConfigurationForm";
 
     protected override void OnInitialized()
     {
         if (Model is not null && FormModel is null) FormModel = Model;
-
-        if (FormModel is not null) return;
-
-        FormModel = new AuthenticationConfigurationFormModel();
+        
+        FormModel ??= new AuthenticationConfigurationFormModel();
+        
+        FormEditContext = new EditContext(FormModel);
+        FormValidationMessageStore = new ValidationMessageStore(FormEditContext);
     }
 
     private async Task SubmitAsync()
     {
-        await OnSubmitFunction.InvokeAsync(FormModel);
+        try
+        {
+            await OnSubmitFunction.InvokeAsync(FormModel);
+        }
+        catch (PasswordlessApiException e)
+        {
+            FormValidationMessageStore!.Add(() => FormModel!.Purpose, e.Details.Title);
+            FormEditContext!.NotifyValidationStateChanged();
+            Logger.LogError(e, "Failed to save authentication configuration");
+        }
     }
 }

--- a/src/AdminConsole/Program.cs
+++ b/src/AdminConsole/Program.cs
@@ -115,12 +115,13 @@ async Task RunAppAsync()
     services.AddHostedService<ApplicationCleanupBackgroundService>();
 
     services.AddTransient<IScopedPasswordlessClient, ScopedPasswordlessClient>();
+    services.AddTransient<ProblemDetailsDelegatingHandler>();
     services.AddHttpClient<IScopedPasswordlessClient, ScopedPasswordlessClient>((provider, client) =>
     {
         var options = provider.GetRequiredService<IOptions<PasswordlessManagementOptions>>();
 
         client.BaseAddress = new Uri(options.Value.InternalApiUrl);
-    });
+    }).AddHttpMessageHandler<ProblemDetailsDelegatingHandler>();
 
     // Magic link SigninManager
     services.AddTransient<IMagicLinkBuilder, MagicLinkBuilder>();

--- a/src/AdminConsole/Services/ProblemDetailsDelegatingHandler.cs
+++ b/src/AdminConsole/Services/ProblemDetailsDelegatingHandler.cs
@@ -1,0 +1,30 @@
+using Passwordless.Helpers;
+
+namespace Passwordless.AdminConsole.Services;
+
+public class ProblemDetailsDelegatingHandler : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (string.Equals(
+                response.Content.Headers.ContentType?.MediaType,
+                "application/problem+json",
+                StringComparison.OrdinalIgnoreCase)
+           )
+        {
+            var problemDetails = await response.Content.ReadFromJsonAsync(
+                PasswordlessSerializerContext.Default.PasswordlessProblemDetails,
+                cancellationToken
+            );
+
+            if (problemDetails is not null)
+                throw new PasswordlessApiException(problemDetails);
+        }
+
+        return response;
+    }
+}


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-557](https://bitwarden.atlassian.net/browse/PAS-557)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

It is now properly showing the error message when an error is being returned by the Passwordless.dev back-end.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-557]: https://bitwarden.atlassian.net/browse/PAS-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ