### PR TITLE
PAS-560 | Playground crashing w/ new user without 'Hints' field

### DIFF
--- a/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml.cs
@@ -15,7 +15,7 @@ public class NewAccountModel(IScopedPasswordlessClient passwordlessClient)
 
     public string Hints { get; set; } = "";
 
-    public async Task<IActionResult> OnPostToken(string name, string email, string attestation, string hints)
+    public async Task<IActionResult> OnPostToken(string name, string email, string attestation, string? hints = null)
     {
         try
         {
@@ -26,7 +26,7 @@ public class NewAccountModel(IScopedPasswordlessClient passwordlessClient)
                 Aliases = [email],
                 AliasHashing = false,
                 Attestation = attestation,
-                Hints = hints.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                Hints = hints?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
             });
 
             return new JsonResult(token);


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-560](https://bitwarden.atlassian.net/browse/PAS-560)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

`Hints` field is null, causing it to crash on the line where it tries to split the string by comma separated values.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-560]: https://bitwarden.atlassian.net/browse/PAS-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ