### PR TITLE
PAS-380 | Bug where version query parameter gets rendered repeatedly.

### DIFF
--- a/src/AdminConsole/Components/Shared/SecureImportMapScript.razor
+++ b/src/AdminConsole/Components/Shared/SecureImportMapScript.razor
@@ -4,6 +4,6 @@
 @if (Value.Imports.Count > 0)
 {
     <script type="importmap" nonce="@Nonce">
-        @((MarkupString)JsonSerializer.Serialize(Value, JsonSerializerOptions))
+        @((MarkupString)JsonSerializer.Serialize(_model, JsonSerializerOptions))
     </script>
 }

--- a/src/AdminConsole/Components/Shared/SecureImportMapScript.razor.cs
+++ b/src/AdminConsole/Components/Shared/SecureImportMapScript.razor.cs
@@ -6,6 +6,8 @@ namespace Passwordless.AdminConsole.Components.Shared;
 
 public partial class SecureImportMapScript
 {
+    private Model? _model;
+
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -34,9 +36,17 @@ public partial class SecureImportMapScript
 
     protected override void OnInitialized()
     {
+        if (_model != null)
+        {
+            return;
+        }
+        _model = new Model
+        {
+            Imports = new Dictionary<string, string>(Value.Imports.Count)
+        };
         foreach (var import in Value.Imports)
         {
-            Value.Imports[import.Key] = Version.Get(import.Value);
+            _model.Imports.Add(import.Key, Version.Get(import.Value));
         }
     }
 


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-380](https://bitwarden.atlassian.net/browse/PAS-380)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

The version query parameter was being rendered repeatedly, causing the Vue dependency not to be found. Possibly this could have had an impact on other inline rendered scripts, even if they don't rely on Vue.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-380]: https://bitwarden.atlassian.net/browse/PAS-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ