### PR TITLE
Improve integration tests performance

### DIFF
--- a/tests/Api.IntegrationTests/ApiCollectionFixture.cs
+++ b/tests/Api.IntegrationTests/ApiCollectionFixture.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+namespace Passwordless.Api.IntegrationTests;
+
+[CollectionDefinition(Fixture)]
+public class ApiCollectionFixture : ICollectionFixture<PasswordlessApiFixture>
+{
+    internal const string Fixture = "Api";
+
+}

--- a/tests/Api.IntegrationTests/AuthorizationTests.cs
+++ b/tests/Api.IntegrationTests/AuthorizationTests.cs
@@ -9,8 +9,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class AuthorizationTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     // Manual opt out for endpoints that allow anonymous access, all other endpoints are considered to require
     // some kind of authentication

--- a/tests/Api.IntegrationTests/Endpoints/App/AppTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/App/AppTests.cs
@@ -17,8 +17,8 @@ using SetFeaturesRequest = Passwordless.Common.Models.Apps.SetFeaturesRequest;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.App;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class AppTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     [Theory]
     [InlineData("a")]

--- a/tests/Api.IntegrationTests/Endpoints/AuthenticationConfiguration/AuthenticationConfigurationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/AuthenticationConfiguration/AuthenticationConfigurationTests.cs
@@ -13,8 +13,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.AuthenticationConfiguration;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class AuthenticationConfigurationTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     [Fact]
     public async Task I_can_create_an_authentication_configuration()

--- a/tests/Api.IntegrationTests/Endpoints/Authenticators/AuthenticatorsTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Authenticators/AuthenticatorsTests.cs
@@ -4,7 +4,6 @@ using Bogus;
 using FluentAssertions;
 using Passwordless.Api.IntegrationTests.Helpers;
 using Passwordless.Api.IntegrationTests.Helpers.App;
-using Passwordless.Common.Models.Apps;
 using Passwordless.Common.Models.Authenticators;
 using Passwordless.Service.Models;
 using Xunit;
@@ -12,8 +11,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Authenticators;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class AuthenticatorsTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     private static readonly Faker<RegisterToken> TokenGenerator = new Faker<RegisterToken>()
         .RuleFor(x => x.UserId, Guid.NewGuid().ToString())

--- a/tests/Api.IntegrationTests/Endpoints/Credentials/CredentialsTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Credentials/CredentialsTests.cs
@@ -15,8 +15,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Credentials;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class CredentialsTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     private readonly Faker<RegisterToken> _tokenGenerator = RequestHelpers.GetRegisterTokenGeneratorRules();
 

--- a/tests/Api.IntegrationTests/Endpoints/Events/EventsTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Events/EventsTests.cs
@@ -14,8 +14,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Events;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class EventsTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     [Fact]
     public async Task I_can_view_the_event_for_a_user_retrieving_the_api_keys()

--- a/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Magic/MagicTests.cs
@@ -12,8 +12,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Magic;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class MagicTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     private readonly Faker<SendMagicLinkRequest> _requestFaker = RequestHelpers.GetMagicLinkRequestRules();
 

--- a/tests/Api.IntegrationTests/Endpoints/Register/RegisterAttestationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Register/RegisterAttestationTests.cs
@@ -14,8 +14,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Register;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class RegisterAttestationTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     private static readonly Faker<RegisterToken> TokenGenerator = new Faker<RegisterToken>()
         .RuleFor(x => x.UserId, Guid.NewGuid().ToString())

--- a/tests/Api.IntegrationTests/Endpoints/Register/RegisterTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Register/RegisterTests.cs
@@ -13,8 +13,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Register;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class RegisterTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     private readonly Faker<RegisterToken> _tokenGenerator = RequestHelpers.GetRegisterTokenGeneratorRules();
 

--- a/tests/Api.IntegrationTests/Endpoints/Register/RegisterTokenTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/Register/RegisterTokenTests.cs
@@ -10,8 +10,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.Register;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class RegisterTokenTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     [Fact]
     public async Task UserIdAndDisplayNameIsTheOnlyRequiredProperties()

--- a/tests/Api.IntegrationTests/Endpoints/SignIn/SignInTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/SignIn/SignInTests.cs
@@ -7,7 +7,6 @@ using Passwordless.Api.Endpoints;
 using Passwordless.Api.IntegrationTests.Helpers;
 using Passwordless.Api.IntegrationTests.Helpers.App;
 using Passwordless.Api.IntegrationTests.Helpers.User;
-using Passwordless.Common.Models.Apps;
 using Passwordless.Service.Models;
 using Passwordless.Service.Storage.Ef;
 using Xunit;
@@ -15,8 +14,8 @@ using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Endpoints.SignIn;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class SignInTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     [Fact]
     public async Task I_can_retrieve_assertion_options_to_begin_sign_in()

--- a/tests/Api.IntegrationTests/Middleware/AuthorizationIntegrationTests.cs
+++ b/tests/Api.IntegrationTests/Middleware/AuthorizationIntegrationTests.cs
@@ -2,14 +2,13 @@ using System.Net;
 using System.Net.Http.Json;
 using Passwordless.Api.IntegrationTests.Helpers;
 using Passwordless.Api.IntegrationTests.Helpers.App;
-using Passwordless.Common.Models.Apps;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Middleware;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class AuthorizationIntegrationTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
 
     [Fact]

--- a/tests/Api.IntegrationTests/Middleware/RoutingIntegrationTests.cs
+++ b/tests/Api.IntegrationTests/Middleware/RoutingIntegrationTests.cs
@@ -1,15 +1,13 @@
 using System.Net;
-using System.Net.Http.Json;
 using Passwordless.Api.IntegrationTests.Helpers;
 using Passwordless.Api.IntegrationTests.Helpers.App;
-using Passwordless.Common.Models.Apps;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests.Middleware;
 
+[Collection(ApiCollectionFixture.Fixture)]
 public class RoutingIntegrationTests(ITestOutputHelper testOutput, PasswordlessApiFixture apiFixture)
-    : IClassFixture<PasswordlessApiFixture>
 {
     [Fact]
     public async Task I_receive_a_404_when_i_use_a_badly_formatted_api_secret_with_a_non_existing_endpoint()

--- a/tests/Api.IntegrationTests/PasswordlessApiFixture.cs
+++ b/tests/Api.IntegrationTests/PasswordlessApiFixture.cs
@@ -1,6 +1,5 @@
 using Testcontainers.MsSql;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Passwordless.Api.IntegrationTests;
 


### PR DESCRIPTION
### Description

Significantly reduces the resources required to run the integration tests as it reuses the Microsoft SQL Server test container.

If the tests are properly written, we should not see any issues. In case we do need a unique instance, we can just use a different collection identifier.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
