### PR TITLE
Wait Strategy needs to be changed for TestContainers

### DIFF
--- a/tests/Api.IntegrationTests/PasswordlessApiFixture.cs
+++ b/tests/Api.IntegrationTests/PasswordlessApiFixture.cs
@@ -1,3 +1,4 @@
+using DotNet.Testcontainers.Builders;
 using Testcontainers.MsSql;
 using Xunit;
 
@@ -5,7 +6,10 @@ namespace Passwordless.Api.IntegrationTests;
 
 public class PasswordlessApiFixture : IAsyncDisposable, IAsyncLifetime
 {
-    private readonly MsSqlContainer _dbContainer = new MsSqlBuilder().Build();
+    private readonly MsSqlContainer _dbContainer = new MsSqlBuilder()
+        .WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd", "-C", "-Q", "SELECT 1;"))
+        .Build();
 
     public async Task InitializeAsync() => await _dbContainer.StartAsync();
 


### PR DESCRIPTION
### Description

After upgrading to Docker 4.33, I cannot get the integration tests to work on either Windows or Mac OS. This appears to work on both. There are some posts mentioning that the way we need to check for a ready SQL Server container has changed recently:
- https://github.com/testcontainers/testcontainers-dotnet/issues/1220

Confirmed to work on:
- MacOS w/ Docker 4.32
- MacOS w/ Docker 4.33
- Windows 11 w/ Docker 4.33.1

Not working on:
- Windows 11 w/ Docker 4.32

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
