### PR TITLE
Do not execute event logging middleware on undefined endpoints

### DIFF
--- a/src/Api/Middleware/PathValidation.cs
+++ b/src/Api/Middleware/PathValidation.cs
@@ -2,11 +2,17 @@ using Passwordless.Common.HealthChecks;
 
 namespace Passwordless.Api.Middleware;
 
+/// <summary>
+/// Defines the conditions under which the middleware should run.
+/// </summary>
 public static class PathValidation
 {
     private const string RootPath = "/";
 
-    public static Func<HttpContext, bool> ShouldRunEventLogMiddleware = o =>
+    /// <summary>
+    /// Defines the condition when the event logging middleware should run.
+    /// </summary>
+    public static readonly Func<HttpContext, bool> ShouldRunEventLogMiddleware = o =>
     {
         // If the incoming request is the root, we don't want to execute this middleware.
         if (o.Request.Path == RootPath)

--- a/src/Api/Middleware/PathValidation.cs
+++ b/src/Api/Middleware/PathValidation.cs
@@ -1,0 +1,26 @@
+using Passwordless.Common.HealthChecks;
+
+namespace Passwordless.Api.Middleware;
+
+public static class PathValidation
+{
+    private const string RootPath = "/";
+
+    public static Func<HttpContext, bool> ShouldRunEventLogMiddleware = o =>
+    {
+        // If the incoming request is the root, we don't want to execute this middleware.
+        if (o.Request.Path == RootPath)
+        {
+            return false;
+        }
+
+        // If the incoming request is the root, we don't want to execute this middleware.
+        if (o.GetEndpoint() == null)
+        {
+            return false;
+        }
+
+        // Ignore health check endpoints
+        return !o.Request.Path.StartsWithSegments(HealthCheckEndpoints.Path);
+    };
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -139,14 +139,7 @@ if (builder.Configuration.IsSelfHosted())
 app.UseCors("default");
 app.UseSecurityHeaders();
 app.UseStaticFiles();
-app.UseWhen(o =>
-{
-    if (o.Request.Path == "/")
-    {
-        return false;
-    }
-    return !o.Request.Path.StartsWithSegments(HealthCheckEndpoints.Path);
-}, c =>
+app.UseWhen(PathValidation.ShouldRunEventLogMiddleware, c =>
 {
     c.UseMiddleware<EventLogStorageCommitMiddleware>();
 });
@@ -154,14 +147,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<LoggingMiddleware>();
 app.UseSerilog();
-app.UseWhen(o =>
-{
-    if (o.Request.Path == "/")
-    {
-        return false;
-    }
-    return !o.Request.Path.StartsWithSegments(HealthCheckEndpoints.Path);
-}, c =>
+app.UseWhen(PathValidation.ShouldRunEventLogMiddleware, c =>
 {
     c.UseMiddleware<EventLogContextMiddleware>();
 });


### PR DESCRIPTION
### Description

The middleware shouldn't be executing on undefined endpoints, given there's nothing to log.

### Shape


### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
