### PR TITLE
Add hacky validation for hints during registration

### DIFF
--- a/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml
+++ b/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml
@@ -119,10 +119,25 @@ document.addEventListener('DOMContentLoaded', function() {
 document.getElementById('register-btn').addEventListener('click', (e) => createNewAccount(e));
 
 const createNewAccount = async (e) => {
-    let form = document.getElementById("registration-form");
+    const form = document.getElementById("registration-form");
     const data = new FormData(form);
 
-    let req = await fetch("?handler=token", {
+    // Validation
+    if (data.get("hints")) {
+        const hints = data.get("hints").split(",").map(h => h.trim().toLowerCase());
+
+        if (new Set(hints).size !== hints.length) {
+            alert("You cannot provide duplicate hints.");
+            return;
+        }
+
+        if (!hints.every(h => ["client-device", "security-key", "hybrid"].includes(h))) {
+            alert("Hint values must be either 'client-device', 'security-key', or 'hybrid'.");
+            return;
+        }
+    }
+
+    const res = await fetch("?handler=token", {
         method: "post",
         body: data,
         headers: {
@@ -130,8 +145,8 @@ const createNewAccount = async (e) => {
         }
     });
 
-    if (req.ok) {
-        const { token } = await req.json();
+    if (res.ok) {
+        const { token } = await res.json();
         const nicknameForDevice = data.get("nickname");
         const { error } = await p.register(token, nicknameForDevice);
 
@@ -144,8 +159,7 @@ const createNewAccount = async (e) => {
     } else {
         const container = document.getElementById("error-message-summary-container");
         const field = container.getElementsByClassName("alert-box-message")[0];
-        const body = await req.text();
-        const problemDetails = JSON.parse(body);
+        const problemDetails = await res.json();
         field.textContent = problemDetails.title;
         container.classList.remove("hidden");
     }

--- a/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml.cs
+++ b/src/AdminConsole/Pages/App/Playground/NewAccount.cshtml.cs
@@ -26,7 +26,7 @@ public class NewAccountModel(IScopedPasswordlessClient passwordlessClient)
                 Aliases = [email],
                 AliasHashing = false,
                 Attestation = attestation,
-                Hints = hints?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                Hints = hints?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries) ?? []
             });
 
             return new JsonResult(token);


### PR DESCRIPTION
Part of PAS-472

Since we're sending the form data using Vue and completely bypassing Razor Pages request pipeline, the validation attributes are not properly honored. I've added validation for Hints in Vue to avoid vague 400 errors on invalid hints. This is hacky, but a proper solution would require rewriting the page to not use Vue to send the registration request, or have better validation infrastructure on our front-end. I don't think it's worth the effort, given other priorities.