### PR TITLE
PAS-561: Verify input with the SupplyFromQueryParameterAttribute

### DIFF
--- a/src/AdminConsole/Services/MagicLinks/MagicLinkSignInManager.cs
+++ b/src/AdminConsole/Services/MagicLinks/MagicLinkSignInManager.cs
@@ -22,7 +22,7 @@ public class MagicLinkSignInManager<TUser>(
     : SignInManager<TUser>(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
     where TUser : class
 {
-    public async Task SendEmailForSignInAsync(string email, string? returnUrl)
+    public virtual async Task SendEmailForSignInAsync(string email, string? returnUrl)
     {
         var user = await UserManager.FindByEmailAsync(email);
         if (user is not ConsoleAdmin admin)
@@ -53,7 +53,7 @@ public class MagicLinkSignInManager<TUser>(
         eventLogger.LogCreateLoginViaMagicLinkEvent(admin);
     }
 
-    public async Task<SignInResult> PasswordlessSignInAsync(string token, bool isPersistent)
+    public virtual async Task<SignInResult> PasswordlessSignInAsync(string token, bool isPersistent)
     {
         try
         {

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Fido2" Version="4.0.0-beta.13" />
     <PackageReference Include="Fido2.Models" Version="4.0.0-beta.13" />
-    <PackageReference Include="HtmlSanitizer" Version="8.1.870" />
+    <PackageReference Include="HtmlSanitizer" Version="8.2.871-beta" />
     <PackageReference Include="MailKit" Version="4.7.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />

--- a/tests/AdminConsole.Tests/AdminConsole.Tests.csproj
+++ b/tests/AdminConsole.Tests/AdminConsole.Tests.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="bunit" Version="1.25.3" />
+    <PackageReference Include="bunit" Version="1.31.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/tests/AdminConsole.Tests/Components/Pages/Account/MagicTests.cs
+++ b/tests/AdminConsole.Tests/Components/Pages/Account/MagicTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Passwordless.AdminConsole.Components.Pages.Account;
 using Passwordless.AdminConsole.Identity;
@@ -15,17 +16,86 @@ public class MagicTests : TestContext
         Services.AddSingleton<MagicLinkSignInManager<ConsoleAdmin>>(new FakeMagicLinkSignInManager());
     }
 
-    [InlineData("")]
-    [Theory]
-    public void OnInitializedAsync_WhenTokenIsEmpty_ShouldSetSuccessToFalse(string? token)
+    [Fact]
+    public void OnInitializedAsync_RendersError_WhenTokenIsNotSpecified()
     {
         // Arrange
-        var cut = RenderComponent<Magic>(p => p
-            .AddCascadingValue("Token", token));
+        var cut = RenderComponent<Magic>();
 
         // Act
 
         // Assert
         Assert.NotNull(cut.Find("#invalid-magic-link-token-alert"));
+    }
+
+    [Fact]
+    public void OnInitializedAsync_DoesNotRender_WhenTokenIsSpecified()
+    {
+        // Arrange
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var token = FakeMagicLinkSignInManager.SuccessToken;
+        var uri = navigationManager.GetUriWithQueryParameter("token", token);
+        navigationManager.NavigateTo(uri);
+
+        var cut = this.RenderComponent<Magic>();
+
+        // Act
+
+        // Assert
+        Assert.Throws<ElementNotFoundException>(() => cut.Find("#invalid-magic-link-token-alert"));
+    }
+
+    [Fact]
+    public void OnInitializedAsync_RendersError_WhenLoginFails()
+    {
+        // Arrange
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var token = FakeMagicLinkSignInManager.FailToken;
+        var uri = navigationManager.GetUriWithQueryParameter("token", token);
+        navigationManager.NavigateTo(uri);
+
+        var cut = this.RenderComponent<Magic>();
+
+        // Act
+
+        // Assert
+        Assert.NotNull(cut.Find("#invalid-magic-link-token-alert"));
+    }
+
+    [Fact]
+    public void OnInitializedAsync_NavigatesToOrganizationOverview_WhenReturnUrlIsNotSetDuringSuccessfulLogin()
+    {
+        // Arrange
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var token = FakeMagicLinkSignInManager.SuccessToken;
+        var uri = navigationManager.GetUriWithQueryParameter("token", token);
+        navigationManager.NavigateTo(uri);
+
+        RenderComponent<Magic>();
+
+        // Act
+
+        // Assert
+        Assert.Equal("http://localhost/Organization/Overview", navigationManager.Uri);
+    }
+
+    [Fact]
+    public void OnInitializedAsync_NavigatesToExpectedReturnUrl_WhenReturnUrlIsSetDuringSuccessfulLogin()
+    {
+        // Arrange
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var token = FakeMagicLinkSignInManager.SuccessToken;
+        var parameters = new Dictionary<string, object?>();
+        parameters.Add("token", token);
+        parameters.Add("returnUrl", "/Organization/Settings");
+        var uri = navigationManager.GetUriWithQueryParameters(parameters);
+        navigationManager.NavigateTo(uri);
+
+        RenderComponent<Magic>();
+
+        // Act
+
+        // Assert
+        Assert.Equal("http://localhost/Organization/Settings", navigationManager.Uri);
     }
 }

--- a/tests/AdminConsole.Tests/DataFactory/FakeMagicLinkSignInManager.cs
+++ b/tests/AdminConsole.Tests/DataFactory/FakeMagicLinkSignInManager.cs
@@ -12,6 +12,9 @@ namespace Passwordless.AdminConsole.Tests.DataFactory;
 
 public class FakeMagicLinkSignInManager : MagicLinkSignInManager<ConsoleAdmin>
 {
+    public const string SuccessToken = "successtoken";
+    public const string FailToken = "failtoken";
+
     public FakeMagicLinkSignInManager()
         : base(
             new Mock<IPasswordlessClient>().Object,
@@ -26,5 +29,18 @@ public class FakeMagicLinkSignInManager : MagicLinkSignInManager<ConsoleAdmin>
             new Mock<IEventLogger>().Object)
     {
 
+    }
+
+    public override async Task<SignInResult> PasswordlessSignInAsync(string token, bool isPersistent)
+    {
+        switch (token)
+        {
+            case SuccessToken:
+                return SignInResult.Success;
+            case FailToken:
+                return SignInResult.Failed;
+            default:
+                return SignInResult.Failed;
+        }
     }
 }


### PR DESCRIPTION
### Ticket
- Closes [PAS-561](https://bitwarden.atlassian.net/browse/PAS-561)

### Description

Wasn't able to unit test pages before when a `SupplyFromQueryParameterAttribute` was being used. The functionality was apparently available in a newer bunit version. But we couldn't upgrade unless we also upgraded `HtmlAgililtyPack`.

There does not seem to be any impact from using a prerelease version of HtmlAgilityPack as its unit tests are still passing as expected.

This pull request will finally allow us to unit test all the bits in the admin console to validate any conditional rendering that may happen.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
