### PR TITLE
PAS-563 | RPID is null on credential cards

### DIFF
--- a/src/AdminConsole/AdminConsole.csproj
+++ b/src/AdminConsole/AdminConsole.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
-    <PackageReference Include="Passwordless.AspNetCore" Version="2.1.0-beta.1" />
+    <PackageReference Include="Passwordless.AspNetCore" Version="2.1.0-beta.2" />
     <PackageReference Include="Stripe.net" Version="41.*" />
   </ItemGroup>
 


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-563](https://bitwarden.atlassian.net/browse/PAS-563)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

Credential cards show an empty value for RPID while the values are being stored correctly.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-563]: https://bitwarden.atlassian.net/browse/PAS-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ