### PR TITLE
Do not override sender for SMTP configuration

### DIFF
--- a/src/Common/Services/Mail/Smtp/SmtpMailProvider.cs
+++ b/src/Common/Services/Mail/Smtp/SmtpMailProvider.cs
@@ -5,7 +5,6 @@ namespace Passwordless.Common.Services.Mail.Smtp;
 
 public class SmtpMailProvider : IMailProvider
 {
-    private readonly string? _fromEmail;
     private readonly string? _smtpUsername;
     private readonly string? _smtpPassword;
     private readonly int _smtpPort;
@@ -18,7 +17,6 @@ public class SmtpMailProvider : IMailProvider
     public SmtpMailProvider(SmtpMailProviderOptions options)
     {
 
-        _fromEmail = options.From;
         _smtpUsername = options.Username;
         _smtpPassword = options.Password;
         _smtpHost = options.Host;
@@ -57,7 +55,7 @@ public class SmtpMailProvider : IMailProvider
 
     private MailboxAddress GetFromAddress(MailMessage message)
     {
-        var from = (_fromEmail ?? message.From)!;
+        var from = message.From!;
 
         return string.IsNullOrEmpty(message.FromDisplayName) ? MailboxAddress.Parse(from) : new MailboxAddress(message.FromDisplayName, from);
     }

--- a/src/Common/Services/Mail/Smtp/SmtpMailProviderOptions.cs
+++ b/src/Common/Services/Mail/Smtp/SmtpMailProviderOptions.cs
@@ -17,8 +17,6 @@ public class SmtpMailProviderOptions : BaseMailProviderOptions
 
     public string? Password { get; set; }
 
-    public string From { get; set; }
-
     public bool StartTls { get; set; }
 
     public bool Ssl { get; set; }


### PR DESCRIPTION
### Description

We do not need to override the sender in the SMTP configuration, as this is being done globally in the `AggregateMailProvider`.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
