### PR TITLE
PAS-452 | Self-hosting and mailing bugs

### DIFF
--- a/run_self-hosting-image.sh
+++ b/run_self-hosting-image.sh
@@ -8,5 +8,5 @@ docker run \
   -p 5701:5701 \
   -e BWP_DOMAIN=yourdomain.com \
   -e BWP_ENABLE_SSL=false \
-  -v /Users/jonashendrickx/passwordless-self-hosting:/etc/bitwarden_passwordless \
+  -v /your/path/passwordless-self-hosting:/etc/bitwarden_passwordless \
   bitwarden/passwordless

--- a/run_self-hosting-image.sh
+++ b/run_self-hosting-image.sh
@@ -2,9 +2,11 @@ docker stop passwordless
 docker rm passwordless
 docker build . -f self-host/Dockerfile -t bitwarden/passwordless
 
+# For Cloudflare tunnel
 docker run \
   --name passwordless \
   -p 5701:5701 \
-  -e BWP_ENABLE_SSL=true \
-  -e BWP_PORT=5701 \
+  -e BWP_DOMAIN=yourdomain.com \
+  -e BWP_ENABLE_SSL=false \
+  -v /Users/jonashendrickx/passwordless-self-hosting:/etc/bitwarden_passwordless \
   bitwarden/passwordless

--- a/self-host/entrypoint.sh
+++ b/self-host/entrypoint.sh
@@ -40,50 +40,6 @@ else
   export ConnectionStrings__sqlite__admin=${ConnectionStrings__sqlite__admin:-$SQLITE_CONNECTION_STRING_ADMIN}
 fi
 
-#################
-# E-mail / SMTP #
-#################
-if [ -z "$BWP_SMTP_FROM" ] || [ "$BWP_SMTP_HOST" == "null" ]; then
-  export Mail__File__Path="$mounted_dir"
-  echo "[Configuration] SMTP E-mail configuration not set. Writing to a local file instead in '/etc/bitwarden_passwordless/mail.md' or your mounted volume. See 'https://docs.passwordless.dev/guide/self-hosting/configuration.html'.";
-else
-  if [ -n "$BWP_SMTP_FROM" ] && [ "$BWP_SMTP_FROM" != "null" ]; then
-    export Mail__Smtp__From=$BWP_SMTP_FROM
-  fi
-
-  if [ -n "$BWP_SMTP_USERNAME" ] && [ "$BWP_SMTP_USERNAME" != "null" ]; then
-    export Mail__Smtp__Username=$BWP_SMTP_USERNAME
-  fi
-
-  if [ -n "$BWP_SMTP_PASSWORD" ] && [ "$BWP_SMTP_PASSWORD" != "null" ]; then
-    export Mail__Smtp__Password=$BWP_SMTP_PASSWORD
-  fi
-
-  if [ -n "$BWP_SMTP_HOST" ] && [ "$BWP_SMTP_HOST" != "null" ]; then
-    export Mail__Smtp__Host=$BWP_SMTP_HOST
-  fi
-
-  if [ -n "$BWP_SMTP_PORT" ] && [ "$BWP_SMTP_PORT" != "null" ]; then
-    export Mail__Smtp__Port=$BWP_SMTP_PORT
-  fi
-
-  if [ -n "$BWP_SMTP_STARTTLS" ] && [ "$BWP_SMTP_STARTTLS" != "null" ]; then
-    export Mail__Smtp__StartTls=$BWP_SMTP_STARTTLS
-  fi
-
-  if [ -n "$BWP_SMTP_SSL" ] && [ "$BWP_SMTP_SSL" != "null" ]; then
-    export Mail__Smtp__Ssl=$BWP_SMTP_SSL
-  fi
-
-  if [ -n "$BWP_SMTP_SSLOVERRIDE" ] && [ "$BWP_SMTP_SSLOVERRIDE" != "null" ]; then
-    export Mail__Smtp__SslOverride=$BWP_SMTP_SSLOVERRIDE
-  fi
-
-  if [ -n "$BWP_SMTP_TRUSTSERVER" ] && [ "$BWP_SMTP_TRUSTSERVER" != "null" ]; then
-    export Mail__Smtp__TrustServer=$BWP_SMTP_TRUSTSERVER
-  fi
-fi
-
 #########################
 # Url #
 #########################

--- a/self-host/entrypoint.sh
+++ b/self-host/entrypoint.sh
@@ -92,20 +92,9 @@ if [ "$BWP_DOMAIN" != "localhost" ] && [ "$BWP_ENABLE_SSL" != "false" ]; then
   echo "[Configuration] WARNING: WebAuthn requires SSL when not running on 'localhost'. This could result in unexpected behavior.";
 fi
 
-if [ "$BWP_ENABLE_SSL" = "true" ]; then
-  echo "[Configuration] SSL: Enabled";
-  scheme="https"
-else
-  echo "[Configuration] SSL: Disabled";
-  scheme="http"
-fi
-if [ "$BWP_PORT" == "null" ]; then
-  echo "WARNING: 'BWP_PORT' not set, defaulting to 5701.";
-  exit 1;
-fi
+export Passwordless__ApiUrl="https://${BWP_DOMAIN}/api/"
+export PasswordlessManagement__ApiUrl="https://${BWP_DOMAIN}/api/"
 
-export Passwordless__ApiUrl="$scheme://${BWP_DOMAIN:-localhost}:${BWP_PORT:-5701}/api"
-export PasswordlessManagement__ApiUrl="$scheme://${BWP_DOMAIN:-localhost}:${BWP_PORT:-5701}/api"
 echo "[Configuration] API public: $PasswordlessManagement__ApiUrl";
 
 ##############################################
@@ -175,8 +164,8 @@ if [ "$BWP_ENABLE_SSL" = "true" ] && [ ! -f /etc/bitwarden_passwordless/${BWP_SS
   -out /etc/bitwarden_passwordless/${BWP_SSL_CERT:-ssl.crt} \
   -reqexts SAN \
   -extensions SAN \
-  -config <(cat /usr/lib/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:${BWP_DOMAIN:-localhost}\nbasicConstraints=CA:true")) \
-  -subj "/C=US/ST=California/L=Santa Barbara/O=Bitwarden Inc./OU=Bitwarden Passwordless/CN=${BWP_DOMAIN:-localhost}"
+  -config <(cat /usr/lib/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:${BWP_DOMAIN}\nbasicConstraints=CA:true")) \
+  -subj "/C=US/ST=California/L=Santa Barbara/O=Bitwarden Inc./OU=Bitwarden Passwordless/CN=${BWP_DOMAIN}"
 fi
 
 # Launch a loop to rotate nginx logs on a daily basis

--- a/src/AdminConsole/Components/Pages/Initialize.razor
+++ b/src/AdminConsole/Components/Pages/Initialize.razor
@@ -19,6 +19,7 @@
 @inject TimeProvider TimeProvider
 @inject UserManager<ConsoleAdmin> UserManager
 @inject ILogger<Initialize> Logger
+@inject IPasswordlessManagementClient PasswordlessManagementClient
 
 <h3>🚀 Let's set up the Admin Console</h3>
 <Alert Style="@ContextualStyles.Warning" class="mt-5">Admin Console is configured to use the API at <strong>@ManagementOptions.Value.ApiUrl</strong></Alert>
@@ -104,19 +105,12 @@
         // Create app in the API
         try
         {
-            using var http = new HttpClient();
-            http.BaseAddress = new Uri(ManagementOptions.Value.ApiUrl);
-            http.DefaultRequestHeaders.Add("ManagementKey", ManagementOptions.Value.ManagementKey);
-
-            using var response = await http.PostAsJsonAsync("/admin/apps/adminconsole/create", new CreateAppDto
+            const string appName = "adminconsole";
+            appCreationResult = await PasswordlessManagementClient.CreateApplicationAsync(appName, new CreateAppDto
             {
                 AdminEmail = Form.AdminEmail,
                 MagicLinkEmailMonthlyQuota = 2000
             });
-
-            response.EnsureSuccessStatusCode();
-
-            appCreationResult = (await response.Content.ReadFromJsonAsync<CreateAppResultDto>())!;
         }
         catch (Exception ex)
         {

--- a/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
+++ b/src/AdminConsole/Services/PasswordlessManagement/PasswordlessManagementClient.cs
@@ -9,7 +9,7 @@ public class PasswordlessManagementClient(HttpClient http) : IPasswordlessManage
     public async Task<CreateAppResultDto> CreateApplicationAsync(string appId, CreateAppDto options)
     {
         using var response = await http.PostAsJsonAsync(
-            $"/admin/apps/{Uri.EscapeDataString(appId)}/create",
+            $"admin/apps/{Uri.EscapeDataString(appId)}/create",
             options
         );
 

--- a/src/Common/Services/Mail/AggregateMailProvider.cs
+++ b/src/Common/Services/Mail/AggregateMailProvider.cs
@@ -25,9 +25,14 @@ public class AggregateMailProvider : IMailProvider
 
     public async Task SendAsync(MailMessage message)
     {
+
         if (message.From == null)
         {
             message.From = _options.Value.From;
+        }
+        if (message.FromDisplayName == null)
+        {
+            message.FromDisplayName = _options.Value.FromName;
         }
         foreach (var providerConfiguration in _options.Value.Providers)
         {

--- a/src/Common/Services/Mail/Aws/AwsMailProvider.cs
+++ b/src/Common/Services/Mail/Aws/AwsMailProvider.cs
@@ -23,7 +23,10 @@ public class AwsMailProvider : IMailProvider
     {
         var request = new SendEmailRequest
         {
-            FromEmailAddress = message.From
+            FromEmailAddress = message.FromDisplayName != null
+                ? $"{message.FromDisplayName} <{message.From}>"
+                : message.From
+
         };
 
         if (message.To.Any())

--- a/src/Common/Services/Mail/MailConfiguration.cs
+++ b/src/Common/Services/Mail/MailConfiguration.cs
@@ -8,6 +8,11 @@ public class MailConfiguration
     public string? From { get; set; }
 
     /// <summary>
+    /// The default name to use as the sender.
+    /// </summary>
+    public string? FromName { get; set; }
+
+    /// <summary>
     /// The ordered list of mail providers to use.
     /// </summary>
     public IReadOnlyCollection<BaseMailProviderOptions> Providers { get; set; } = new List<BaseMailProviderOptions>();

--- a/src/Common/Services/Mail/MailMessage.cs
+++ b/src/Common/Services/Mail/MailMessage.cs
@@ -32,7 +32,7 @@ public class MailMessage
 
     public string? From { get; set; }
 
-    public string FromDisplayName { get; init; }
+    public string? FromDisplayName { get; set; }
 
     public string Subject { get; init; }
 


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-452](https://bitwarden.atlassian.net/browse/PAS-452)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

- Magic links or e-mails were failing to send.
- Magic links or e-mails didn't have a correct displayed sender name.
- Bootstrapping was broken when SSL was disabled. It will now work when we run with `BWP_ENABLE_SSL` set to `false` and the SSL certificates are provided by the load balancer such as Traefik.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
