### PR TITLE
Fixing routing for when you click on Sidebar logo.

### DIFF
--- a/src/AdminConsole/Pages/Account/Login.cshtml.cs
+++ b/src/AdminConsole/Pages/Account/Login.cshtml.cs
@@ -29,8 +29,7 @@ public class LoginModel : PageModel
     {
         if (HttpContext.User.Identity is { IsAuthenticated: true })
         {
-            returnUrl ??= Url.Page("/Organization/Overview");
-            return LocalRedirect(returnUrl);
+            return string.IsNullOrWhiteSpace(returnUrl) ? Redirect("/Organization/Overview") : LocalRedirect(returnUrl);
         }
 
         int? status = (int?)TempData["Status"];


### PR DESCRIPTION

### Description
When clicking on the logo, it would throw 500 because it couldn't find a Razor page for `/Organization/Overview/`. Changed this to a plain redirect since the overview page was migrated to blazor.

### Shape
Changes `LocalRedirect` based off Razor Page to be `Redirect`.


### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Manually tested clicking the logo and ensured routing worked.

I did the following to ensure that my changes do not introduce security vulnerabilities:
- N/A
