### PR TITLE
When no mail providers are registered, fall back to no-op behavior

### DIFF
--- a/src/Common/Services/Mail/AggregateMailProvider.cs
+++ b/src/Common/Services/Mail/AggregateMailProvider.cs
@@ -5,53 +5,32 @@ namespace Passwordless.Common.Services.Mail;
 /// <summary>
 /// Wraps multiple mail providers and tries to send the message using them in order.
 /// </summary>
-public class AggregateMailProvider : IMailProvider
+public class AggregateMailProvider(
+    IOptionsSnapshot<MailConfiguration> options,
+    IMailProviderFactory factory,
+    ILogger<AggregateMailProvider> logger)
+    : IMailProvider
 {
-    private readonly IOptionsSnapshot<MailConfiguration> _options;
-    private readonly IMailProviderFactory _factory;
-    private readonly ILogger<AggregateMailProvider> _logger;
-
-    public const string FallBackFailedMessage = "No registered mail provider was able to send the message";
-
-    public AggregateMailProvider(
-        IOptionsSnapshot<MailConfiguration> options,
-        IMailProviderFactory factory,
-        ILogger<AggregateMailProvider> logger)
-    {
-        _options = options;
-        _factory = factory;
-        _logger = logger;
-    }
-
     public async Task SendAsync(MailMessage message)
     {
+        message.From ??= options.Value.From;
+        message.FromDisplayName ??= options.Value.FromName;
 
-        if (message.From == null)
-        {
-            message.From = _options.Value.From;
-        }
-        if (message.FromDisplayName == null)
-        {
-            message.FromDisplayName = _options.Value.FromName;
-        }
-        foreach (var providerConfiguration in _options.Value.Providers)
+        foreach (var providerConfiguration in options.Value.Providers)
         {
             try
             {
-                _logger.LogDebug("Attempting to send message using provider '{Provider}'", providerConfiguration.Name);
-                var provider = _factory.Create(providerConfiguration.Name, providerConfiguration);
+                logger.LogDebug("Attempting to send message using provider '{Provider}'", providerConfiguration.Name);
+                var provider = factory.Create(providerConfiguration.Name, providerConfiguration);
 
                 await provider.SendAsync(message);
-                _logger.LogInformation("Sent message using provider '{Provider}'", providerConfiguration.Name);
+                logger.LogInformation("Sent message using provider '{Provider}'", providerConfiguration.Name);
                 return;
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Failed to send message using provider '{Provider}'", providerConfiguration.Name);
+                logger.LogError(e, "Failed to send message using provider '{Provider}'", providerConfiguration.Name);
             }
         }
-
-        _logger.LogCritical(FallBackFailedMessage);
-        throw new InvalidOperationException(FallBackFailedMessage);
     }
 }

--- a/src/Common/Services/Mail/MailBootstrap.cs
+++ b/src/Common/Services/Mail/MailBootstrap.cs
@@ -17,26 +17,12 @@ public static class MailBootstrap
             {
                 var section = builder.Configuration.GetSection("Mail:Providers");
 
-                if (!section.GetChildren().Any())
-                {
-                    o.Providers = new List<BaseMailProviderOptions>
-                    {
-                        new FileMailProviderOptions()
-                    };
-                    return;
-                }
-
                 // Iterate over all configured providers and add them to the list with binding.
-
                 var providers = new List<BaseMailProviderOptions>();
                 foreach (var child in section.GetChildren())
                 {
-                    var type = child.GetValue<string>("Name");
-
-                    if (type == null)
-                    {
-                        throw new ConfigurationErrorsException("Provider type is missing");
-                    }
+                    var type = child.GetValue<string>("Name")
+                               ?? throw new ConfigurationErrorsException("Provider type is missing");
 
                     BaseMailProviderOptions mailProviderOptions = type.ToLowerInvariant() switch
                     {
@@ -52,6 +38,7 @@ public static class MailBootstrap
 
                     providers.Add(mailProviderOptions);
                 }
+
                 o.Providers = providers;
             });
     }

--- a/src/Common/Services/Mail/MailConfiguration.cs
+++ b/src/Common/Services/Mail/MailConfiguration.cs
@@ -15,5 +15,5 @@ public class MailConfiguration
     /// <summary>
     /// The ordered list of mail providers to use.
     /// </summary>
-    public IReadOnlyCollection<BaseMailProviderOptions> Providers { get; set; } = new List<BaseMailProviderOptions>();
+    public IReadOnlyCollection<BaseMailProviderOptions> Providers { get; set; } = [];
 }

--- a/tests/Common.Tests/Services/Mail/AggregateMailProviderTests.cs
+++ b/tests/Common.Tests/Services/Mail/AggregateMailProviderTests.cs
@@ -27,6 +27,18 @@ public class AggregateMailProviderTests
     }
 
     [Fact]
+    public async Task SendAsync_NoOp_WhenNoProvidersAreRegistered()
+    {
+        // Arrange
+        var mailMessage = _fixture.Create<MailMessage>();
+        var mailOptions = new MailConfiguration { From = "johndoe@example.com", Providers = [] };
+        _optionsMock.SetupGet(x => x.Value).Returns(mailOptions);
+
+        // Act & assert
+        await _sut.SendAsync(mailMessage);
+    }
+
+    [Fact]
     public async Task SendAsync_Overrides_MailMessageSenderFromConfiguration_WhenMailMessageHasNoSender()
     {
         // Arrange
@@ -34,27 +46,30 @@ public class AggregateMailProviderTests
         var mailOptions = new MailConfiguration
         {
             From = "johndoe@example.com",
-            Providers = new List<BaseMailProviderOptions>
-            {
+            Providers =
+            [
                 _fixture.Build<AwsMailProviderOptions>()
                     .With(x => x.Name, AwsMailProviderOptions.Provider)
                     .Create(),
                 _fixture.Build<SendGridMailProviderOptions>()
                     .With(x => x.Name, SendGridMailProviderOptions.Provider)
                     .Create()
-            }
+            ]
         };
         _optionsMock.SetupGet(x => x.Value).Returns(mailOptions);
 
         var awsProviderMock = new Mock<IMailProvider>();
-        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<BaseMailProviderOptions>()))
+        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider),
+                It.IsAny<BaseMailProviderOptions>()))
             .Returns(awsProviderMock.Object);
 
         // Act
         await _sut.SendAsync(mailMessage);
 
         // Assert
-        _factoryMock.Verify(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()), Times.Once);
+        _factoryMock.Verify(
+            x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()),
+            Times.Once);
         awsProviderMock.Verify(x => x.SendAsync(It.Is<MailMessage>(p => p.From == mailOptions.From)), Times.Once);
     }
 
@@ -66,27 +81,30 @@ public class AggregateMailProviderTests
         var mailOptions = new MailConfiguration
         {
             From = "johndoe@example.com",
-            Providers = new List<BaseMailProviderOptions>
-            {
+            Providers =
+            [
                 _fixture.Build<AwsMailProviderOptions>()
                     .With(x => x.Name, AwsMailProviderOptions.Provider)
                     .Create(),
                 _fixture.Build<SendGridMailProviderOptions>()
                     .With(x => x.Name, SendGridMailProviderOptions.Provider)
                     .Create()
-            }
+            ]
         };
         _optionsMock.SetupGet(x => x.Value).Returns(mailOptions);
 
         var awsProviderMock = new Mock<IMailProvider>();
-        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<BaseMailProviderOptions>()))
+        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider),
+                It.IsAny<BaseMailProviderOptions>()))
             .Returns(awsProviderMock.Object);
 
         // Act
         await _sut.SendAsync(mailMessage);
 
         // Assert
-        _factoryMock.Verify(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()), Times.Once);
+        _factoryMock.Verify(
+            x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()),
+            Times.Once);
         awsProviderMock.Verify(x => x.SendAsync(It.Is<MailMessage>(p => p.From == mailOptions.From)), Times.Never);
         awsProviderMock.Verify(x => x.SendAsync(It.Is<MailMessage>(p => p.From == mailMessage.From)), Times.Once);
     }
@@ -100,27 +118,30 @@ public class AggregateMailProviderTests
         var mailOptions = new MailConfiguration
         {
             From = "johndoe@example.com",
-            Providers = new List<BaseMailProviderOptions>
-            {
+            Providers =
+            [
                 _fixture.Build<AwsMailProviderOptions>()
                     .With(x => x.Name, AwsMailProviderOptions.Provider)
                     .Create(),
                 _fixture.Build<SendGridMailProviderOptions>()
                     .With(x => x.Name, SendGridMailProviderOptions.Provider)
                     .Create()
-            }
+            ]
         };
         _optionsMock.SetupGet(x => x.Value).Returns(mailOptions);
 
         var awsProviderMock = new Mock<IMailProvider>();
-        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<BaseMailProviderOptions>()))
+        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider),
+                It.IsAny<BaseMailProviderOptions>()))
             .Returns(awsProviderMock.Object);
 
         // Act
         await _sut.SendAsync(mailMessage);
 
         // Assert
-        _factoryMock.Verify(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()), Times.Once);
+        _factoryMock.Verify(
+            x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()),
+            Times.Once);
     }
 
     [Fact]
@@ -131,34 +152,40 @@ public class AggregateMailProviderTests
         var mailOptions = new MailConfiguration
         {
             From = "johndoe@example.com",
-            Providers = new List<BaseMailProviderOptions>
-            {
+            Providers =
+            [
                 _fixture.Build<AwsMailProviderOptions>()
                     .With(x => x.Name, AwsMailProviderOptions.Provider)
                     .Create(),
                 _fixture.Build<SendGridMailProviderOptions>()
                     .With(x => x.Name, SendGridMailProviderOptions.Provider)
                     .Create()
-            }
+            ]
         };
         _optionsMock.SetupGet(x => x.Value).Returns(mailOptions);
 
         var awsProviderMock = new Mock<IMailProvider>();
         awsProviderMock.Setup(x => x.SendAsync(It.IsAny<MailMessage>()))
             .Throws<Exception>();
-        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<BaseMailProviderOptions>()))
+        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider),
+                It.IsAny<BaseMailProviderOptions>()))
             .Returns(awsProviderMock.Object);
 
         var sendGridProviderMock = new Mock<IMailProvider>();
-        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == SendGridMailProviderOptions.Provider), It.IsAny<BaseMailProviderOptions>()))
+        _factoryMock.Setup(x => x.Create(It.Is<string>(y => y == SendGridMailProviderOptions.Provider),
+                It.IsAny<BaseMailProviderOptions>()))
             .Returns(sendGridProviderMock.Object);
 
         // Act
         await _sut.SendAsync(mailMessage);
 
         // Assert
-        _factoryMock.Verify(x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()), Times.Once);
-        _factoryMock.Verify(x => x.Create(It.Is<string>(y => y == SendGridMailProviderOptions.Provider), It.IsAny<SendGridMailProviderOptions>()), Times.Once);
+        _factoryMock.Verify(
+            x => x.Create(It.Is<string>(y => y == AwsMailProviderOptions.Provider), It.IsAny<AwsMailProviderOptions>()),
+            Times.Once);
+        _factoryMock.Verify(
+            x => x.Create(It.Is<string>(y => y == SendGridMailProviderOptions.Provider),
+                It.IsAny<SendGridMailProviderOptions>()), Times.Once);
 
     }
 }

--- a/tests/Common.Tests/Services/Mail/AggregateMailProviderTests.cs
+++ b/tests/Common.Tests/Services/Mail/AggregateMailProviderTests.cs
@@ -27,26 +27,6 @@ public class AggregateMailProviderTests
     }
 
     [Fact]
-    public async Task SendAsync_Throws_InvalidOperationException_WhenNoProvidersAreRegistered()
-    {
-        // Arrange
-        var mailMessage = _fixture.Create<MailMessage>();
-        var mailOptions = new MailConfiguration
-        {
-            From = "johndoe@example.com",
-            Providers = new List<BaseMailProviderOptions>()
-        };
-        _optionsMock.SetupGet(x => x.Value).Returns(mailOptions);
-
-        // Act
-        var actual = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await _sut.SendAsync(mailMessage));
-
-        // Assert
-        Assert.Equal(AggregateMailProvider.FallBackFailedMessage, actual.Message);
-    }
-
-    [Fact]
     public async Task SendAsync_Overrides_MailMessageSenderFromConfiguration_WhenMailMessageHasNoSender()
     {
         // Arrange


### PR DESCRIPTION
#705 changed the behavior in regard to how the mail providers are configured:
- Pre-PR, when the application configuration does not specify any mail provider, the emails are not sent.
- Post-PR, when the application configuration does not specify any mail provider, the `FileMailProvider` is used.

The issue is that, in certain scenarios, the application may not be able to write data to the file system and thus may not use the `FileMailProvider`, making it a poor default choice. This happens, for example, when running in Docker, where the application is executed under an under-privileged user account for security reasons:

![image](https://github.com/user-attachments/assets/dc6a6eeb-dff9-4938-834b-67bba1cdc0aa)

Additionally, there does not appear to be a way to set the `NoopMailProvider` through configuration as it's only defined in tests.

This PR reverts some of the user-facing behavior changes introduced in #705 and makes it so that no emails are sent when the configuration does not specify any mail provider.