### PR TITLE
Fix the publishing of Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,9 +139,9 @@ jobs:
           --build-arg VERSION=${{ needs.version.outputs.version }}
           --push
           ${{ format('--tag {0}/{1}:dev', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) }}
-          ${{ github.event_name == 'release' && github.event.prerelease && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
-          ${{ github.event_name == 'release' && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
-          ${{ github.event_name == 'release' && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release' && github.event.release.prerelease == true && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release'' && github.event.release.prerelease == false && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release'' && github.event.release.prerelease == false && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
           ${{ github.event_name == 'release' && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, github.ref_name) || '' }}
           ${{ inputs.image-tag && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, inputs.image-tag) || '' }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,9 +139,9 @@ jobs:
           --build-arg VERSION=${{ needs.version.outputs.version }}
           --push
           ${{ format('--tag {0}/{1}:dev', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) }}
-          ${{ github.event_name == 'release' && github.event.release.prerelease == true && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
-          ${{ github.event_name == 'release'' && github.event.release.prerelease == false && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
-          ${{ github.event_name == 'release'' && github.event.release.prerelease == false && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release' && github.event.release.prerelease && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release'' && !github.event.release.prerelease && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release'' && !github.event.release.prerelease && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
           ${{ github.event_name == 'release' && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, github.ref_name) || '' }}
           ${{ inputs.image-tag && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, inputs.image-tag) || '' }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -140,8 +140,8 @@ jobs:
           --push
           ${{ format('--tag {0}/{1}:dev', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) }}
           ${{ github.event_name == 'release' && github.event.release.prerelease && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
-          ${{ github.event_name == 'release'' && !github.event.release.prerelease && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
-          ${{ github.event_name == 'release'' && !github.event.release.prerelease && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release' && !github.event.release.prerelease && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release' && !github.event.release.prerelease && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
           ${{ github.event_name == 'release' && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, github.ref_name) || '' }}
           ${{ inputs.image-tag && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, inputs.image-tag) || '' }}
 


### PR DESCRIPTION
### Ticket

- Closes #712 

### Description

When we pull Docker images, we would expect to have `latest` always reflect a stable release or production release by default. Now, the latest tag seems to pull any image that is in the main branch or in QA testing.

I've changed the behavior to below, so people can still continue testing the latest `qa` or `dev` build separately. While the latest production release will carry the tags `latest` and `stable` in addition to their respective build numbers.

- `push to main` -> `dev`
- `prerelease release` -> `qa`
- `release` -> `latest` & `stable`

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
