### PR TITLE
Always release image to 'qa' upon release event

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,7 +139,7 @@ jobs:
           --build-arg VERSION=${{ needs.version.outputs.version }}
           --push
           ${{ format('--tag {0}/{1}:dev', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) }}
-          ${{ github.event_name == 'release' && github.event.release.prerelease && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
+          ${{ github.event_name == 'release' && format('--tag {0}/{1}:qa', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
           ${{ github.event_name == 'release' && !github.event.release.prerelease && format('--tag {0}/{1}:latest', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
           ${{ github.event_name == 'release' && !github.event.release.prerelease && format('--tag {0}/{1}:stable', env.DOCKER_CONTAINER_NAMESPACE, matrix.name) || '' }}
           ${{ github.event_name == 'release' && format('--tag {0}/{1}:{2}', env.DOCKER_CONTAINER_NAMESPACE, matrix.name, github.ref_name) || '' }}


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-XXX](https://bitwarden.atlassian.net/browse/PAS-XXX)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

We should always push a image with the 'qa' tag when a release event happens.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
