### PR TITLE
#731 | TimeToLive is not an obsolete property

### DIFF
--- a/src/Service/Models/SigninTokenRequest.cs
+++ b/src/Service/Models/SigninTokenRequest.cs
@@ -16,7 +16,6 @@ public class SigninTokenRequest : RequestBase
     /// Time to live is the number of seconds the token has before it expires.
     /// </summary>
     [JsonPropertyName("timeToLive")]
-    [Obsolete("This property is only used for serialization.")]
     [Range(1, 604800)]
     public int? TimeToLiveSeconds { get; init; }
 


### PR DESCRIPTION
### Ticket

<!-- For GitHub Issues: -->
<!-- - Closes #731 -->


### Description

This is not an obsolete property as it's actually being used. This will incorrectly hide it from our Open API documentation.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
