### PR TITLE
PAS-584 | Duplicate ApiSecret / ApiKey header fields in swagger

### DIFF
--- a/src/Api/Endpoints/AuthenticationConfiguration.cs
+++ b/src/Api/Endpoints/AuthenticationConfiguration.cs
@@ -28,7 +28,6 @@ public static class AuthenticationConfigurationEndpoints
                         .Select(dto => dto.ToResponse())
                 });
             })
-            .WithOpenApi()
             .WithSummary("A list of authentication scope configurations for your application. This will include the two default scopes of SignIn and StepUp.")
             .Produces<GetAuthenticationConfigurationsResult>()
             .RequireSecretKey();
@@ -41,7 +40,6 @@ public static class AuthenticationConfigurationEndpoints
 
                 return Created();
             })
-            .WithOpenApi()
             .WithSummary("Creates an authentication configuration for the authentication process. In order to use this, it will have to be provided to the `stepup` client method via the purpose field")
             .Produces(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
@@ -57,7 +55,6 @@ public static class AuthenticationConfigurationEndpoints
 
                 return NoContent();
             })
-            .WithOpenApi()
             .WithSummary("Updates an authentication configuration for the authentication process. In order to use this, it will have to be provided to the `stepup` client method via the purpose field")
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status404NotFound)
@@ -79,7 +76,6 @@ public static class AuthenticationConfigurationEndpoints
 
                 return NoContent();
             })
-            .WithOpenApi()
             .WithSummary("Deletes an authentication configuration for the provided purpose.")
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status400BadRequest)


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-584](https://bitwarden.atlassian.net/browse/PAS-584)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->


### Description

The header fields for `ApiSecret` and `ApiKey` are duplicated, this is caused by the `.WithOpenApi()` method being used for these endpoints.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-584]: https://bitwarden.atlassian.net/browse/PAS-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ