### PR TITLE
Remove references to Codecov token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,8 +143,6 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Publish the apps
   pack:


### PR DESCRIPTION
### Description

Removes the Codecov token which is no longer needed to upload results.
