### PR TITLE
[BRE-831] migrate secrets AKV

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,6 +115,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -123,12 +124,22 @@ jobs:
       - name: Install Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
       - name: Setup Docker Content Trust
         id: setup-dct
         uses: bitwarden/gh-actions/setup-docker-trust@main
         with:
-          azure-creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
           azure-keyvault-name: "bitwarden-ci"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Build & push image
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -138,7 +138,7 @@ jobs:
         with:
           azure-keyvault-name: "bitwarden-ci"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Build & push image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,7 +125,6 @@ jobs:
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,7 +224,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,16 +212,34 @@ jobs:
           # Deploy to DEVTEST every time
 
     runs-on: ubuntu-24.04
-    permissions: {} # no permissions required
+    permissions:
+      id-token: write
 
     steps:
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets-ghapp
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
       
       - name: Generate GH App token
         uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
         id: app-token
         with:
-          app-id: ${{ secrets.BW_GHAPP_ID }}
-          private-key: ${{ secrets.BW_GHAPP_KEY }}
+          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
           owner: bitwarden
           repositories: passwordless-devops
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,7 +216,7 @@ jobs:
       id-token: write
 
     steps:
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -224,14 +224,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
       
       - name: Generate GH App token

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,7 +217,6 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,7 @@ jobs:
     permissions: {} # no permissions required
 
     steps:
+      
       - name: Generate GH App token
         uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
         id: app-token

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,7 +225,7 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Get KV secrets
-        id: get-kv-secrets-ghapp
+        id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-831](https://bitwarden.atlassian.net/browse/BRE-831)

## 📔 Objective

Updating to use Azure Key Vault Secrets in place of GitHub secrets.
All GitHub secrets have been migrated to the repository's respective Key Vault.
Azure Service Principals have been updated to use Managed Identities with OIDC.

[BRE-831]: https://bitwarden.atlassian.net/browse/BRE-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ