### PR TITLE
[PAS-592] - Downgrade FluentAssertions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,11 @@
       "groupName": "nuget minor",
       "matchManagers": ["nuget"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "FluentAssertions",
+      "matchPackageNames": ["FluentAssertions"],
+      "allowedVersions": "<8.0.0"
     }
   ],
   "ignoreDeps": ["Datadog.Trace", "dotnet-sdk"]

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.1"/>
-    <PackageReference Include="FluentAssertions" Version="8.0.1"/>
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1"/>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.1.0" />

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">

--- a/tests/Common.Tests/Common.Tests.csproj
+++ b/tests/Common.Tests/Common.Tests.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/Service.Tests/Service.Tests.csproj
+++ b/tests/Service.Tests/Service.Tests.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
### Ticket
<!-- For Jira Tasks: (remove if external contributor)  -->
- Closes [PAS-592](https://bitwarden.atlassian.net/browse/PAS-592)

### Description
Since fluent assertions went with a commercial license, we are going to stay off the license at this point in time.

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- ✅  Ran tests

I did the following to ensure that my changes do not introduce security vulnerabilities:
- ✅  No endpoints changed and no known security issues with these versions.


[PAS-592]: https://bitwarden.atlassian.net/browse/PAS-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ