### PR TITLE
[PAS-596] Add wrapper type for AuthenticatorAttestationRawResponse

### DIFF
--- a/src/Service/Extensions/Models/AuthenticatorAttestationRawResponseExtensions.cs
+++ b/src/Service/Extensions/Models/AuthenticatorAttestationRawResponseExtensions.cs
@@ -10,11 +10,11 @@ public static class Fido2MappingExtensions
     {
         ArgumentNullException.ThrowIfNull(dto);
         ArgumentException.ThrowIfNullOrWhiteSpace(dto.Id);
-        
+
         if (dto.RawId is { Length: 0 }) throw new ArgumentException("RawId was empty");
-        
+
         if (dto.Type == PublicKeyCredentialType.Invalid) throw new ArgumentException("PublicKeyCredentialType was invalid");
-        
+
         return new AuthenticatorAttestationRawResponse
         {
             Id = dto.Id,

--- a/src/Service/Extensions/Models/AuthenticatorAttestationRawResponseExtensions.cs
+++ b/src/Service/Extensions/Models/AuthenticatorAttestationRawResponseExtensions.cs
@@ -1,0 +1,38 @@
+using Fido2NetLib;
+using Fido2NetLib.Objects;
+using Passwordless.Service.Models;
+
+namespace Passwordless.Service.Extensions.Models;
+
+public static class Fido2MappingExtensions
+{
+    public static AuthenticatorAttestationRawResponse ToRawResponse(this AuthenticatorAttestationResponseDTO dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dto.Id);
+        
+        if (dto.RawId is { Length: 0 }) throw new ArgumentException("RawId was empty");
+        
+        if (dto.Type == PublicKeyCredentialType.Invalid) throw new ArgumentException("PublicKeyCredentialType was invalid");
+        
+        return new AuthenticatorAttestationRawResponse
+        {
+            Id = dto.Id,
+            RawId = dto.RawId,
+            Type = dto.Type,
+            Response = dto.Response.ToResponse(),
+            Extensions = dto.ClientExtensionResults
+        };
+    }
+
+    public static AuthenticatorAttestationRawResponse.AttestationResponse ToResponse(
+        this AuthenticatorAttestationResponseDataDTO dto)
+    {
+        return new AuthenticatorAttestationRawResponse.AttestationResponse
+        {
+            AttestationObject = dto.AttestationObject,
+            ClientDataJson = dto.ClientDataJson,
+            Transports = dto.Transports
+        };
+    }
+}

--- a/src/Service/Fido2Service.cs
+++ b/src/Service/Fido2Service.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Passwordless.Service.EventLog.Loggers;
+using Passwordless.Service.Extensions.Models;
 using Passwordless.Service.Features;
 using Passwordless.Service.Helpers;
 using Passwordless.Service.Models;
@@ -192,7 +193,7 @@ public class Fido2Service : IFido2Service
         {
             var makeNewCredentialParams = new MakeNewCredentialParams
             {
-                AttestationResponse = request.Response,
+                AttestationResponse = request.Response.ToRawResponse(),
                 OriginalOptions = session.Options,
                 IsCredentialIdUniqueToUserCallback = async (args, _) =>
                 {

--- a/src/Service/Models/AuthenticatorAttestationResponseDTO.cs
+++ b/src/Service/Models/AuthenticatorAttestationResponseDTO.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Fido2NetLib;
+using Fido2NetLib.Objects;
+
+namespace Passwordless.Service.Models;
+
+/// <summary>
+/// DTO representing an AuthenticatorAttestationResponse from the WebAuthn API.
+/// This contains the data returned by the authenticator during credential registration.
+/// </summary>
+public class AuthenticatorAttestationResponseDTO
+{
+    /// <summary>
+    /// The credential ID as a base64url-encoded string.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The raw credential ID as a byte array.
+    /// </summary>
+    [JsonConverter(typeof(Base64UrlConverter))]
+    [JsonPropertyName("rawId")]
+    public required byte[] RawId { get; init; }
+
+    /// <summary>
+    /// The type of credential (typically "public-key").
+    /// </summary>
+    [Required]
+    [JsonPropertyName("type")]
+    public PublicKeyCredentialType Type { get; init; }
+
+    /// <summary>
+    /// The authenticator's response data.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("response")]
+    public AuthenticatorAttestationResponseDataDTO Response { get; init; }
+
+    /// <summary>
+    /// Optional authenticator attachment information.
+    /// </summary>
+    [JsonPropertyName("authenticatorAttachment")]
+    public string AuthenticatorAttachment { get; init; }
+
+    /// <summary>
+    /// Client extension results (optional).
+    /// </summary>
+    [JsonPropertyName("clientExtensionResults")]
+    public AuthenticationExtensionsClientOutputs ClientExtensionResults { get; init; }
+}
+
+/// <summary>
+/// DTO representing the response data within an AuthenticatorAttestationResponse.
+/// </summary>
+public class AuthenticatorAttestationResponseDataDTO
+{
+    /// <summary>
+    /// JSON-serialized client data as a byte array.
+    /// Contains challenge, origin, and other client information.
+    /// </summary>
+    [JsonConverter(typeof(Base64UrlConverter))]
+    [JsonPropertyName("clientDataJSON")]
+    public required byte[] ClientDataJson { get; init; }
+
+    /// <summary>
+    /// The attestation object containing the authenticator data and attestation statement.
+    /// This includes the public key and attestation information.
+    /// </summary>
+    [JsonConverter(typeof(Base64UrlConverter))]
+    [JsonPropertyName("attestationObject")]
+    public required byte[] AttestationObject { get; init; }
+
+    /// <summary>
+    /// Optional transports supported by the authenticator. (soon to be required)
+    /// </summary>
+    [JsonPropertyName("transports")]
+    public AuthenticatorTransport[] Transports { get; init; } = [];
+}

--- a/src/Service/Models/RegistrationCompleteDTO.cs
+++ b/src/Service/Models/RegistrationCompleteDTO.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using Fido2NetLib;
 
 namespace Passwordless.Service.Models;
 
@@ -7,7 +6,7 @@ public class RegistrationCompleteDTO : RequestBase
 {
     public string Session { get; set; }
 
-    public AuthenticatorAttestationRawResponse Response { get; set; }
+    public AuthenticatorAttestationResponseDTO Response { get; set; }
 
     [MaxLength(64, ErrorMessage = "Nickname cannot be longer than 64 characters.")]
     public string Nickname { get; set; }

--- a/tests/Api.IntegrationTests/Helpers/BrowserCredentialsHelper.cs
+++ b/tests/Api.IntegrationTests/Helpers/BrowserCredentialsHelper.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Fido2NetLib;
 using OpenQA.Selenium;
+using Passwordless.Service.Models;
 
 namespace Passwordless.Api.IntegrationTests.Helpers;
 
@@ -23,15 +24,15 @@ public static class BrowserCredentialsHelper
         return result;
     }
 
-    public static async Task<AuthenticatorAttestationRawResponse> CreateCredentialsAsync(CredentialCreateOptions options, string originUrl)
+    public static async Task<AuthenticatorAttestationResponseDTO> CreateCredentialsAsync(CredentialCreateOptions options, string originUrl)
     {
         using var driver = WebDriverFactory.GetDriver(originUrl);
 
         return await driver.CreateCredentialsAsync(options);
     }
 
-    public static async Task<AuthenticatorAttestationRawResponse> CreateCredentialsAsync(this IJavaScriptExecutor webDriver, CredentialCreateOptions options) =>
-        JsonSerializer.Deserialize<AuthenticatorAttestationRawResponse>(
+    public static async Task<AuthenticatorAttestationResponseDTO> CreateCredentialsAsync(this IJavaScriptExecutor webDriver, CredentialCreateOptions options) =>
+        JsonSerializer.Deserialize<AuthenticatorAttestationResponseDTO>(
             webDriver.ExecuteScript($"{await GetCreateCredentialFunctions()} return await createCredential({options.ToJson()});").ToString()
              ?? string.Empty)!;
 


### PR DESCRIPTION
### Ticket
- Closes [PAS-596](https://bitwarden.atlassian.net/browse/PAS-596)


### Description
Added wrapper class for AuthenticatorAttestationRawResponse so that we could default the value for Transports.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __


[PAS-596]: https://bitwarden.atlassian.net/browse/PAS-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ